### PR TITLE
Centralize user role creation

### DIFF
--- a/custom-rental-car-manager.php
+++ b/custom-rental-car-manager.php
@@ -611,8 +611,9 @@ add_action('plugins_loaded', 'crcm', 10);
 /**
  * MANUAL ROLE CREATION FUNCTION - For immediate testing
  * Add this to wp-admin/plugins.php?crcm_create_roles=1 for manual trigger
+ * Requires CRCM_ALLOW_ROLE_REPAIR constant set to true.
  */
-if (isset($_GET['crcm_create_roles']) && current_user_can('manage_options')) {
+if (defined('CRCM_ALLOW_ROLE_REPAIR') && CRCM_ALLOW_ROLE_REPAIR && isset($_GET['crcm_create_roles']) && current_user_can('manage_options')) {
     add_action('admin_init', function() {
         if (file_exists(CRCM_PLUGIN_PATH . 'inc/functions.php')) {
             require_once CRCM_PLUGIN_PATH . 'inc/functions.php';
@@ -626,7 +627,7 @@ if (isset($_GET['crcm_create_roles']) && current_user_can('manage_options')) {
 }
 
 // Show success message
-if (isset($_GET['crcm_roles_created'])) {
+if (defined('CRCM_ALLOW_ROLE_REPAIR') && CRCM_ALLOW_ROLE_REPAIR && isset($_GET['crcm_roles_created'])) {
     add_action('admin_notices', function() {
         echo '<div class="notice notice-success is-dismissible">';
         echo '<p><strong>Custom Rental Manager:</strong> User roles created successfully!</p>';

--- a/inc/class-booking-manager.php
+++ b/inc/class-booking-manager.php
@@ -20,7 +20,6 @@ class CRCM_Booking_Manager {
      * Constructor
      */
     public function __construct() {
-        add_action('init', array($this, 'ensure_user_roles'));
         add_action('add_meta_boxes', array($this, 'add_meta_boxes'));
         add_action('save_post', array($this, 'save_booking_meta'));
         
@@ -42,76 +41,7 @@ class CRCM_Booking_Manager {
         // Admin styles
         add_action('admin_head', array($this, 'admin_booking_styles'));
     }
-    
-    /**
-     * Ensure custom user roles exist and are properly configured
-     */
-    public function ensure_user_roles() {
-        // Remove roles first to ensure clean setup
-        remove_role('crcm_customer');
-        remove_role('crcm_manager');
-        
-        // Create Customer role with specific capabilities
-        add_role('crcm_customer', __('Rental Customer', 'custom-rental-manager'), array(
-            'read' => true,
-            'crcm_view_own_bookings' => true,
-            'crcm_edit_own_profile' => true,
-            'crcm_cancel_bookings' => true,
-        ));
-        
-        // Create Manager role with comprehensive capabilities
-        add_role('crcm_manager', __('Rental Manager', 'custom-rental-manager'), array(
-            'read' => true,
-            'edit_posts' => true,
-            'edit_others_posts' => true,
-            'publish_posts' => true,
-            'delete_posts' => true,
-            'delete_others_posts' => true,
-            'manage_categories' => true,
-            'upload_files' => true,
-            
-            // Vehicle management
-            'crcm_manage_vehicles' => true,
-            'crcm_edit_vehicles' => true,
-            'crcm_delete_vehicles' => true,
-            'crcm_publish_vehicles' => true,
-            
-            // Booking management
-            'crcm_manage_bookings' => true,
-            'crcm_edit_bookings' => true,
-            'crcm_delete_bookings' => true,
-            'crcm_publish_bookings' => true,
-            'crcm_view_all_bookings' => true,
-            
-            // Customer management
-            'crcm_manage_customers' => true,
-            'crcm_view_customer_data' => true,
-            'crcm_edit_customer_profiles' => true,
-            
-            // Reports and analytics
-            'crcm_view_reports' => true,
-            'crcm_export_data' => true,
-        ));
-        
-        // Add capabilities to administrator
-        $admin = get_role('administrator');
-        if ($admin) {
-            $capabilities = array(
-                'crcm_manage_vehicles', 'crcm_edit_vehicles', 'crcm_delete_vehicles', 'crcm_publish_vehicles',
-                'crcm_manage_bookings', 'crcm_edit_bookings', 'crcm_delete_bookings', 'crcm_publish_bookings',
-                'crcm_view_all_bookings', 'crcm_manage_customers', 'crcm_view_customer_data',
-                'crcm_edit_customer_profiles', 'crcm_view_reports', 'crcm_export_data'
-            );
-            
-            foreach ($capabilities as $cap) {
-                $admin->add_cap($cap);
-            }
-        }
-        
-        // Ensure roles are properly registered
-        wp_roles()->reinit();
-    }
-    
+
     /**
      * Add meta boxes for booking post type
      */

--- a/inc/class-vehicle-manager.php
+++ b/inc/class-vehicle-manager.php
@@ -66,7 +66,6 @@ class CRCM_Vehicle_Manager {
      * Constructor
      */
     public function __construct() {
-        add_action('init', array($this, 'create_user_roles'));
         add_action('init', array($this, 'remove_vehicle_supports'), 20);
         add_action('add_meta_boxes', array($this, 'add_meta_boxes'));
         add_action('save_post', array($this, 'save_vehicle_meta'));
@@ -74,49 +73,11 @@ class CRCM_Vehicle_Manager {
         add_action('wp_ajax_nopriv_crcm_search_vehicles', array($this, 'ajax_search_vehicles'));
         add_filter('manage_crcm_vehicle_posts_columns', array($this, 'vehicle_columns'));
         add_action('manage_crcm_vehicle_posts_custom_column', array($this, 'vehicle_column_content'), 10, 2);
-        
+
         // AJAX handlers
         add_action('wp_ajax_crcm_get_vehicle_fields', array($this, 'ajax_get_vehicle_fields'));
     }
-    
-    /**
-     * Create custom user roles
-     */
-    public function create_user_roles() {
-        // Customer role for rental clients
-        if (!get_role('crcm_customer')) {
-            add_role('crcm_customer', __('Rental Customer', 'custom-rental-manager'), array(
-                'read' => true,
-                'crcm_view_bookings' => true,
-                'crcm_manage_profile' => true,
-            ));
-        }
-        
-        // Manager role for rental operations
-        if (!get_role('crcm_manager')) {
-            add_role('crcm_manager', __('Rental Manager', 'custom-rental-manager'), array(
-                'read' => true,
-                'edit_posts' => true,
-                'edit_others_posts' => true,
-                'publish_posts' => true,
-                'manage_categories' => true,
-                'crcm_manage_vehicles' => true,
-                'crcm_manage_bookings' => true,
-                'crcm_manage_customers' => true,
-                'crcm_view_reports' => true,
-            ));
-        }
-        
-        // Add capabilities to administrator
-        $admin = get_role('administrator');
-        if ($admin) {
-            $admin->add_cap('crcm_manage_vehicles');
-            $admin->add_cap('crcm_manage_bookings');
-            $admin->add_cap('crcm_manage_customers');
-            $admin->add_cap('crcm_view_reports');
-        }
-    }
-    
+
     /**
      * Remove editor and other supports from vehicle post type
      */

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -20,7 +20,7 @@ if (!defined('ABSPATH')) {
 
 /**
  * Create and manage custom user roles for rental system
- * Called on plugin activation and init
+ * Called on plugin activation or via repair tool
  */
 function crcm_create_custom_user_roles() {
     // Remove existing roles to ensure clean setup
@@ -148,10 +148,7 @@ function crcm_create_custom_user_roles() {
     update_option('crcm_roles_version', '1.0.0');
 }
 
-/**
- * Hook role creation to plugin activation and init
- */
-add_action('init', 'crcm_create_custom_user_roles', 1);
+// Role creation is triggered on plugin activation or through the repair tool.
 
 /**
  * Assign default customer role to new users


### PR DESCRIPTION
## Summary
- consolidate user role creation into `crcm_create_custom_user_roles`
- remove redundant role setup from vehicle and booking managers
- gate manual role repair tool behind `CRCM_ALLOW_ROLE_REPAIR`

## Testing
- `php -l inc/class-vehicle-manager.php`
- `php -l inc/class-booking-manager.php`
- `php -l inc/functions.php`
- `php -l custom-rental-car-manager.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689124f0c1cc83338e8b8caf5419ea6b