### PR TITLE
Hook REST API routes into rest_api_init

### DIFF
--- a/custom-rental-car-manager.php
+++ b/custom-rental-car-manager.php
@@ -167,7 +167,7 @@ class CRCM_Plugin {
             $this->payment_manager = new CRCM_Payment_Manager();
         }
         
-        if (class_exists('CRCM_API_Endpoints')) {
+        if ( class_exists( 'CRCM_API_Endpoints' ) && null === $this->api_endpoints ) {
             $this->api_endpoints = new CRCM_API_Endpoints();
         }
         

--- a/inc/class-api-endpoints.php
+++ b/inc/class-api-endpoints.php
@@ -17,46 +17,53 @@ if (!defined('ABSPATH')) {
 class CRCM_API_Endpoints {
 
     /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+    }
+
+    /**
      * Register REST API routes
      */
     public function register_routes() {
-        register_rest_route('crcm/v1', '/vehicles', array(
-            'methods' => 'GET',
-            'callback' => array($this, 'get_vehicles'),
+        register_rest_route( 'crcm/v1', '/vehicles', array(
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'get_vehicles' ),
             'permission_callback' => '__return_true',
-            'args' => array(
+            'args'                => array(
                 'pickup_date' => array(
                     'required' => false,
-                    'type' => 'string',
-                    'format' => 'date',
+                    'type'     => 'string',
+                    'format'   => 'date',
                 ),
                 'return_date' => array(
                     'required' => false,
-                    'type' => 'string',
-                    'format' => 'date',
+                    'type'     => 'string',
+                    'format'   => 'date',
                 ),
                 'vehicle_type' => array(
                     'required' => false,
-                    'type' => 'string',
+                    'type'     => 'string',
                 ),
                 'location' => array(
                     'required' => false,
-                    'type' => 'integer',
+                    'type'     => 'integer',
                 ),
             ),
-        ));
+        ) );
 
-        register_rest_route('crcm/v1', '/vehicles/(?P<id>\d+)', array(
-            'methods' => 'GET',
-            'callback' => array($this, 'get_vehicle'),
+        register_rest_route( 'crcm/v1', '/vehicles/(?P<id>\d+)', array(
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'get_vehicle' ),
             'permission_callback' => '__return_true',
-            'args' => array(
+            'args'                => array(
                 'id' => array(
                     'required' => true,
-                    'type' => 'integer',
+                    'type'     => 'integer',
                 ),
             ),
-        ));
+        ) );
 
         register_rest_route('crcm/v1', '/bookings', array(
             array(


### PR DESCRIPTION
## Summary
- Hook CRCM_API_Endpoints::register_routes to `rest_api_init` via new constructor
- Instantiate API endpoints only once when plugin managers init

## Testing
- `php -l inc/class-api-endpoints.php`
- `php -l custom-rental-car-manager.php`
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: no package.json)*
- `php /tmp/test-routes.php`

------
https://chatgpt.com/codex/tasks/task_e_689144dd54fc8333acbde68e54e211e5