### PR TITLE
Use global manager instances

### DIFF
--- a/inc/class-api-endpoints.php
+++ b/inc/class-api-endpoints.php
@@ -153,7 +153,7 @@ class CRCM_API_Endpoints {
      * Get vehicles endpoint
      */
     public function get_vehicles($request) {
-        $vehicle_manager = new CRCM_Vehicle_Manager();
+        $vehicle_manager = crcm()->vehicle_manager;
 
         $pickup_date = $request->get_param('pickup_date');
         $return_date = $request->get_param('return_date');
@@ -201,7 +201,7 @@ class CRCM_API_Endpoints {
      */
     public function get_vehicle($request) {
         $vehicle_id = $request->get_param('id');
-        $vehicle_manager = new CRCM_Vehicle_Manager();
+        $vehicle_manager = crcm()->vehicle_manager;
 
         $vehicle = $vehicle_manager->get_vehicle($vehicle_id);
 
@@ -237,7 +237,7 @@ class CRCM_API_Endpoints {
         $bookings = array();
 
         foreach ($posts as $post) {
-            $booking_manager = new CRCM_Booking_Manager();
+            $booking_manager = crcm()->booking_manager;
             $bookings[] = $booking_manager->get_booking($post->ID);
         }
 
@@ -264,7 +264,7 @@ class CRCM_API_Endpoints {
             'notes' => $request->get_param('notes') ?: '',
         );
 
-        $booking_manager = new CRCM_Booking_Manager();
+        $booking_manager = crcm()->booking_manager;
         $result = $booking_manager->create_booking($booking_data);
 
         if (is_wp_error($result)) {
@@ -282,7 +282,7 @@ class CRCM_API_Endpoints {
      */
     public function get_booking($request) {
         $booking_id = $request->get_param('id');
-        $booking_manager = new CRCM_Booking_Manager();
+        $booking_manager = crcm()->booking_manager;
 
         $booking = $booking_manager->get_booking($booking_id);
 
@@ -301,7 +301,7 @@ class CRCM_API_Endpoints {
         $start_date = $request->get_param('start_date');
         $end_date = $request->get_param('end_date');
 
-        $vehicle_manager = new CRCM_Vehicle_Manager();
+        $vehicle_manager = crcm()->vehicle_manager;
         $availability = $vehicle_manager->check_availability($vehicle_id, $start_date, $end_date);
 
         return new WP_REST_Response(array(

--- a/inc/class-customer-portal.php
+++ b/inc/class-customer-portal.php
@@ -130,7 +130,7 @@ class CRCM_Customer_Portal {
         ));
 
         $bookings = array();
-        $booking_manager = new CRCM_Booking_Manager();
+        $booking_manager = crcm()->booking_manager;
 
         foreach ($booking_ids as $booking_id) {
             $booking = $booking_manager->get_booking($booking_id);

--- a/inc/class-payment-manager.php
+++ b/inc/class-payment-manager.php
@@ -125,7 +125,7 @@ class CRCM_Payment_Manager {
      * Calculate total booking cost
      */
     public function calculate_total_cost($booking_data) {
-        $booking_manager = new CRCM_Booking_Manager();
+        $booking_manager = crcm()->booking_manager;
         return $booking_manager->calculate_booking_pricing($booking_data);
     }
 


### PR DESCRIPTION
## Summary
- Reuse global `booking_manager` for payment total calculations
- Utilize plugin-wide managers for REST endpoints instead of creating new instances
- Share booking manager in customer portal for fetching reservations

## Testing
- `php -l inc/class-payment-manager.php`
- `php -l inc/class-api-endpoints.php`
- `php -l inc/class-customer-portal.php`


------
https://chatgpt.com/codex/tasks/task_e_68914a6daac08333b7863bc824060ac8