### PR TITLE
Add capability check to customer search

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -347,7 +347,11 @@ add_action('edit_user_profile_update', 'crcm_save_rental_profile_fields');
  */
 function crcm_ajax_search_customers() {
     check_ajax_referer('crcm_admin_nonce', 'nonce');
-    
+
+    if (!current_user_can('crcm_manage_customers') && !current_user_can('manage_options')) {
+        wp_send_json_error(__('You are not allowed to search customers.', 'custom-rental-manager'));
+    }
+
     $query = sanitize_text_field($_POST['query']);
     
     if (strlen($query) < 2) {


### PR DESCRIPTION
## Summary
- ensure customer search AJAX handler validates user capabilities

## Testing
- `php -l inc/functions.php`
- `find . -name "*.php" -print0 | xargs -0 -n 1 php -l`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68914b88a120833386a266225e424495