### PR TITLE
Add granular booking capabilities and role assignments

### DIFF
--- a/custom-rental-car-manager.php
+++ b/custom-rental-car-manager.php
@@ -198,7 +198,7 @@ class CRCM_Plugin {
             'show_in_menu' => false, // Will be under main menu
         ));
         
-        // Booking post type - NO CHANGES
+        // Booking post type - with granular capabilities
         register_post_type('crcm_booking', array(
             'labels' => array(
                 'name' => __('Bookings', 'custom-rental-manager'),
@@ -210,12 +210,25 @@ class CRCM_Plugin {
             'show_ui' => true,
             'menu_icon' => 'dashicons-calendar-alt',
             'supports' => array('title'),
+            'map_meta_cap' => true,
             'capabilities' => array(
-                'create_posts' => 'manage_options',
-                'edit_posts' => 'manage_options',
-                'edit_others_posts' => 'manage_options',
-                'publish_posts' => 'manage_options',
-                'read_private_posts' => 'manage_options',
+                // Singular capabilities
+                'edit_post'              => 'crcm_edit_booking',
+                'read_post'              => 'crcm_read_booking',
+                'delete_post'            => 'crcm_delete_booking',
+
+                // Plural capabilities
+                'edit_posts'             => 'crcm_edit_bookings',
+                'edit_others_posts'      => 'crcm_edit_others_bookings',
+                'publish_posts'          => 'crcm_publish_bookings',
+                'read_private_posts'     => 'crcm_read_private_bookings',
+                'delete_posts'           => 'crcm_delete_bookings',
+                'delete_private_posts'   => 'crcm_delete_private_bookings',
+                'delete_published_posts' => 'crcm_delete_published_bookings',
+                'delete_others_posts'    => 'crcm_delete_others_bookings',
+                'edit_private_posts'     => 'crcm_edit_private_bookings',
+                'edit_published_posts'   => 'crcm_edit_published_bookings',
+                'create_posts'           => 'crcm_manage_bookings',
             ),
             'rewrite' => false,
             'show_in_menu' => false, // Will be under main menu

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -69,12 +69,19 @@ function crcm_create_custom_user_roles() {
         
         // Booking Management
         'crcm_manage_bookings' => true,
+        'crcm_edit_booking' => true,
+        'crcm_read_booking' => true,
+        'crcm_delete_booking' => true,
         'crcm_edit_bookings' => true,
         'crcm_edit_others_bookings' => true,
         'crcm_publish_bookings' => true,
         'crcm_delete_bookings' => true,
         'crcm_delete_others_bookings' => true,
         'crcm_read_private_bookings' => true,
+        'crcm_edit_private_bookings' => true,
+        'crcm_edit_published_bookings' => true,
+        'crcm_delete_private_bookings' => true,
+        'crcm_delete_published_bookings' => true,
         'crcm_view_all_bookings' => true,
         'crcm_confirm_bookings' => true,
         'crcm_cancel_bookings' => true,
@@ -114,10 +121,13 @@ function crcm_create_custom_user_roles() {
             'crcm_read_private_vehicles',
             
             // Booking capabilities
-            'crcm_manage_bookings', 'crcm_edit_bookings', 'crcm_edit_others_bookings',
+            'crcm_manage_bookings', 'crcm_edit_booking', 'crcm_read_booking',
+            'crcm_delete_booking', 'crcm_edit_bookings', 'crcm_edit_others_bookings',
             'crcm_publish_bookings', 'crcm_delete_bookings', 'crcm_delete_others_bookings',
-            'crcm_read_private_bookings', 'crcm_view_all_bookings', 'crcm_confirm_bookings',
-            'crcm_cancel_bookings',
+            'crcm_read_private_bookings', 'crcm_edit_private_bookings',
+            'crcm_edit_published_bookings', 'crcm_delete_private_bookings',
+            'crcm_delete_published_bookings', 'crcm_view_all_bookings',
+            'crcm_confirm_bookings', 'crcm_cancel_bookings',
             
             // Customer capabilities
             'crcm_manage_customers', 'crcm_view_customer_data', 'crcm_edit_customer_profiles',


### PR DESCRIPTION
## Summary
- define detailed capability mappings for booking post type with `map_meta_cap`
- grant booking capabilities to rental manager and administrator roles

## Testing
- `php -l custom-rental-car-manager.php`
- `php -l inc/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68914f71f73c8333adab7562d1acaf9c