### PR TITLE
Replace deprecated role reinit with for_site

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -150,8 +150,10 @@ function crcm_create_custom_user_roles() {
         }
     }
     
-    // Force WordPress to reinitialize roles
-    wp_roles()->reinit();
+    // Refresh roles for the current site
+    if ( method_exists( wp_roles(), 'for_site' ) ) {
+        wp_roles()->for_site();
+    }
     
     // Set option to track that roles have been created
     update_option('crcm_roles_created', true);


### PR DESCRIPTION
## Summary
- Replace deprecated `wp_roles()->reinit()` with `wp_roles()->for_site()` and guard for method existence
- Ensure role creation refreshes current site roles without triggering deprecation warnings

## Testing
- `php -l inc/functions.php`
- `php test_roles.php` *(custom stub to simulate WordPress role creation without warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68915222427883338b501808cb50f1da