### PR TITLE
Sanitize POST input with defaults

### DIFF
--- a/inc/class-booking-manager.php
+++ b/inc/class-booking-manager.php
@@ -993,7 +993,7 @@ class CRCM_Booking_Manager {
     public function ajax_search_customers() {
         check_ajax_referer('crcm_admin_nonce', 'nonce');
         
-        $query = sanitize_text_field($_POST['query']);
+        $query = sanitize_text_field($_POST['query'] ?? '');
         
         if (strlen($query) < 2) {
             wp_send_json_error('Query too short');
@@ -1028,7 +1028,7 @@ class CRCM_Booking_Manager {
     public function ajax_get_vehicle_booking_data() {
         check_ajax_referer('crcm_admin_nonce', 'nonce');
         
-        $vehicle_id = intval($_POST['vehicle_id']);
+        $vehicle_id = intval($_POST['vehicle_id'] ?? 0);
         
         if (!$vehicle_id) {
             wp_send_json_error('Invalid vehicle ID');
@@ -1065,9 +1065,9 @@ class CRCM_Booking_Manager {
     public function ajax_check_vehicle_availability() {
         check_ajax_referer('crcm_admin_nonce', 'nonce');
         
-        $vehicle_id = intval($_POST['vehicle_id']);
-        $pickup_date = sanitize_text_field($_POST['pickup_date']);
-        $return_date = sanitize_text_field($_POST['return_date']);
+        $vehicle_id = intval($_POST['vehicle_id'] ?? 0);
+        $pickup_date = sanitize_text_field($_POST['pickup_date'] ?? '');
+        $return_date = sanitize_text_field($_POST['return_date'] ?? '');
         
         if (!$vehicle_id || !$pickup_date || !$return_date) {
             wp_send_json_error('Missing required parameters');
@@ -1096,7 +1096,8 @@ class CRCM_Booking_Manager {
      */
     public function save_booking_meta($post_id) {
         // Verify nonce
-        if (!isset($_POST['crcm_booking_meta_nonce_field']) || !wp_verify_nonce($_POST['crcm_booking_meta_nonce_field'], 'crcm_booking_meta_nonce')) {
+        $nonce = $_POST['crcm_booking_meta_nonce_field'] ?? '';
+        if (!$nonce || !wp_verify_nonce($nonce, 'crcm_booking_meta_nonce')) {
             return;
         }
         

--- a/inc/class-calendar-manager.php
+++ b/inc/class-calendar-manager.php
@@ -130,9 +130,9 @@ class CRCM_Calendar_Manager {
 
         global $wpdb;
 
-        $vehicle_id = intval($_POST['vehicle_id']);
-        $date = sanitize_text_field($_POST['date']);
-        $quantity = intval($_POST['quantity']);
+        $vehicle_id = intval($_POST['vehicle_id'] ?? 0);
+        $date = sanitize_text_field($_POST['date'] ?? '');
+        $quantity = intval($_POST['quantity'] ?? 0);
         $price_override = floatval($_POST['price_override'] ?? 0);
         $notes = sanitize_textarea_field($_POST['notes'] ?? '');
 

--- a/inc/class-customer-portal.php
+++ b/inc/class-customer-portal.php
@@ -52,7 +52,7 @@ class CRCM_Customer_Portal {
             wp_send_json_error(__('Please log in to cancel bookings', 'custom-rental-manager'));
         }
 
-        $booking_id = intval($_POST['booking_id']);
+        $booking_id = intval($_POST['booking_id'] ?? 0);
         $current_user = wp_get_current_user();
 
         // Verify this is the customer's booking
@@ -91,16 +91,16 @@ class CRCM_Customer_Portal {
         $current_user_id = get_current_user_id();
 
         $profile_data = array(
-            'first_name' => sanitize_text_field($_POST['first_name']),
-            'last_name' => sanitize_text_field($_POST['last_name']),
-            'phone' => sanitize_text_field($_POST['phone']),
-            'date_of_birth' => sanitize_text_field($_POST['date_of_birth']),
-            'license_number' => sanitize_text_field($_POST['license_number']),
-            'license_country' => sanitize_text_field($_POST['license_country']),
-            'address' => sanitize_text_field($_POST['address']),
-            'city' => sanitize_text_field($_POST['city']),
-            'postal_code' => sanitize_text_field($_POST['postal_code']),
-            'country' => sanitize_text_field($_POST['country']),
+            'first_name' => sanitize_text_field($_POST['first_name'] ?? ''),
+            'last_name' => sanitize_text_field($_POST['last_name'] ?? ''),
+            'phone' => sanitize_text_field($_POST['phone'] ?? ''),
+            'date_of_birth' => sanitize_text_field($_POST['date_of_birth'] ?? ''),
+            'license_number' => sanitize_text_field($_POST['license_number'] ?? ''),
+            'license_country' => sanitize_text_field($_POST['license_country'] ?? ''),
+            'address' => sanitize_text_field($_POST['address'] ?? ''),
+            'city' => sanitize_text_field($_POST['city'] ?? ''),
+            'postal_code' => sanitize_text_field($_POST['postal_code'] ?? ''),
+            'country' => sanitize_text_field($_POST['country'] ?? ''),
         );
 
         // Update WordPress user meta

--- a/inc/class-payment-manager.php
+++ b/inc/class-payment-manager.php
@@ -31,9 +31,9 @@ class CRCM_Payment_Manager {
     public function process_payment() {
         check_ajax_referer('crcm_nonce', 'nonce');
 
-        $booking_id = intval($_POST['booking_id']);
-        $payment_method_id = sanitize_text_field($_POST['payment_method_id']);
-        $amount = floatval($_POST['amount']);
+        $booking_id = intval($_POST['booking_id'] ?? 0);
+        $payment_method_id = sanitize_text_field($_POST['payment_method_id'] ?? '');
+        $amount = floatval($_POST['amount'] ?? 0);
 
         if (!$booking_id || !$payment_method_id || $amount <= 0) {
             wp_send_json_error(__('Invalid payment data', 'custom-rental-manager'));
@@ -83,9 +83,9 @@ class CRCM_Payment_Manager {
             wp_send_json_error(__('Permission denied', 'custom-rental-manager'));
         }
 
-        $booking_id = intval($_POST['booking_id']);
-        $refund_amount = floatval($_POST['refund_amount']);
-        $refund_reason = sanitize_textarea_field($_POST['refund_reason']);
+        $booking_id = intval($_POST['booking_id'] ?? 0);
+        $refund_amount = floatval($_POST['refund_amount'] ?? 0);
+        $refund_reason = sanitize_textarea_field($_POST['refund_reason'] ?? '');
 
         $payment_data = get_post_meta($booking_id, '_crcm_payment_data', true);
 

--- a/inc/class-vehicle-manager.php
+++ b/inc/class-vehicle-manager.php
@@ -1478,7 +1478,7 @@ class CRCM_Vehicle_Manager {
     public function ajax_get_vehicle_fields() {
         check_ajax_referer('crcm_admin_nonce', 'nonce');
         
-        $vehicle_type = sanitize_text_field($_POST['vehicle_type']);
+        $vehicle_type = sanitize_text_field($_POST['vehicle_type'] ?? '');
         $vehicle_data = array(); // Default empty data
         
         ob_start();
@@ -1494,7 +1494,7 @@ class CRCM_Vehicle_Manager {
     public function ajax_get_vehicle_features() {
         check_ajax_referer('crcm_admin_nonce', 'nonce');
         
-        $vehicle_type = sanitize_text_field($_POST['vehicle_type']);
+        $vehicle_type = sanitize_text_field($_POST['vehicle_type'] ?? '');
         $available_features = $this->vehicle_types[$vehicle_type]['features'];
         
         ob_start();
@@ -1518,7 +1518,8 @@ class CRCM_Vehicle_Manager {
      */
     public function save_vehicle_meta($post_id) {
         // Verify nonce
-        if (!isset($_POST['crcm_vehicle_meta_nonce_field']) || !wp_verify_nonce($_POST['crcm_vehicle_meta_nonce_field'], 'crcm_vehicle_meta_nonce')) {
+        $nonce = $_POST['crcm_vehicle_meta_nonce_field'] ?? '';
+        if (!$nonce || !wp_verify_nonce($nonce, 'crcm_vehicle_meta_nonce')) {
             return;
         }
         
@@ -1549,7 +1550,7 @@ class CRCM_Vehicle_Manager {
         // Save pricing data
         if (isset($_POST['pricing_data'])) {
             $pricing_data = array();
-            $pricing_data['daily_rate'] = floatval($_POST['pricing_data']['daily_rate']);
+            $pricing_data['daily_rate'] = floatval($_POST['pricing_data']['daily_rate'] ?? 0);
             
             // Save custom rates
             if (isset($_POST['pricing_data']['custom_rates'])) {
@@ -1561,7 +1562,7 @@ class CRCM_Vehicle_Manager {
                             'type' => sanitize_text_field($rate['type']),
                             'start_date' => sanitize_text_field($rate['start_date'] ?? ''),
                             'end_date' => sanitize_text_field($rate['end_date'] ?? ''),
-                            'extra_rate' => floatval($rate['extra_rate']),
+                            'extra_rate' => floatval($rate['extra_rate'] ?? 0),
                         );
                     }
                 }
@@ -1580,7 +1581,7 @@ class CRCM_Vehicle_Manager {
                         'name' => sanitize_text_field($rule['name']),
                         'start_date' => sanitize_text_field($rule['start_date']),
                         'end_date' => sanitize_text_field($rule['end_date']),
-                        'quantity_to_remove' => sanitize_text_field($rule['quantity_to_remove']),
+                        'quantity_to_remove' => intval($rule['quantity_to_remove'] ?? 0),
                     );
                 }
             }
@@ -1602,7 +1603,7 @@ class CRCM_Vehicle_Manager {
                 if (!empty($service['name']) && isset($service['daily_rate'])) {
                     $extras_data[] = array(
                         'name' => sanitize_text_field($service['name']),
-                        'daily_rate' => floatval($service['daily_rate']),
+                        'daily_rate' => floatval($service['daily_rate'] ?? 0),
                     );
                 }
             }

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -364,7 +364,7 @@ function crcm_ajax_search_customers() {
         wp_send_json_error(__('You are not allowed to search customers.', 'custom-rental-manager'));
     }
 
-    $query = sanitize_text_field($_POST['query']);
+    $query = sanitize_text_field($_POST['query'] ?? '');
     
     if (strlen($query) < 2) {
         wp_send_json_error('Query too short');
@@ -411,9 +411,9 @@ function crcm_ajax_create_customer() {
         wp_send_json_error('Permission denied');
     }
     
-    $name = sanitize_text_field($_POST['name']);
-    $email = sanitize_email($_POST['email']);
-    $phone = sanitize_text_field($_POST['phone']);
+    $name = sanitize_text_field($_POST['name'] ?? '');
+    $email = sanitize_email($_POST['email'] ?? '');
+    $phone = sanitize_text_field($_POST['phone'] ?? '');
     
     if (!$name || !$email) {
         wp_send_json_error('Name and email are required');

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Handle form submission
-if (isset($_POST['submit']) && wp_verify_nonce($_POST['crcm_settings_nonce'], 'crcm_save_settings')) {
+if (isset($_POST['submit']) && wp_verify_nonce($_POST['crcm_settings_nonce'] ?? '', 'crcm_save_settings')) {
     $settings = array();
     
     // Company settings


### PR DESCRIPTION
## Summary
- guard `$_POST` access with null-coalescing and numeric casting across booking, payment, calendar, customer, vehicle managers
- add nonce checks with safe defaults and sanitize admin settings submission

## Testing
- `php -l inc/class-booking-manager.php`
- `php -l inc/class-calendar-manager.php`
- `php -l inc/class-customer-portal.php`
- `php -l inc/class-payment-manager.php`
- `php -l inc/class-vehicle-manager.php`
- `php -l inc/functions.php`
- `php -l templates/admin/settings.php`
- `npm test` *(fails: package.json not found)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6891542a85a48333ada8ce3c19402e88