### PR TITLE
Add booking creation and retrieval with validation

### DIFF
--- a/inc/class-api-endpoints.php
+++ b/inc/class-api-endpoints.php
@@ -238,7 +238,10 @@ class CRCM_API_Endpoints {
 
         foreach ($posts as $post) {
             $booking_manager = crcm()->booking_manager;
-            $bookings[] = $booking_manager->get_booking($post->ID);
+            $booking = $booking_manager->get_booking($post->ID);
+            if (!is_wp_error($booking)) {
+                $bookings[] = $booking;
+            }
         }
 
         return new WP_REST_Response($bookings, 200);
@@ -286,7 +289,7 @@ class CRCM_API_Endpoints {
 
         $booking = $booking_manager->get_booking($booking_id);
 
-        if (!$booking) {
+        if (is_wp_error($booking)) {
             return new WP_Error('booking_not_found', __('Booking not found', 'custom-rental-manager'), array('status' => 404));
         }
 

--- a/inc/class-customer-portal.php
+++ b/inc/class-customer-portal.php
@@ -126,7 +126,7 @@ class CRCM_Customer_Portal {
 
         foreach ($booking_posts as $booking_post) {
             $booking = $booking_manager->get_booking($booking_post->ID);
-            if ($booking) {
+            if (!is_wp_error($booking)) {
                 $vehicle = get_post($booking['booking_data']['vehicle_id']);
                 $booking['vehicle_name']  = $vehicle ? $vehicle->post_title : '';
                 $booking['vehicle_image'] = get_the_post_thumbnail_url($booking['booking_data']['vehicle_id'], 'medium');

--- a/inc/class-email-manager.php
+++ b/inc/class-email-manager.php
@@ -38,7 +38,7 @@ class CRCM_Email_Manager {
     public function send_booking_confirmation($booking_id) {
         $booking = $this->get_booking_data($booking_id);
 
-        if (!$booking || empty($booking['customer_data']['email'])) {
+        if (is_wp_error($booking) || empty($booking['customer_data']['email'])) {
             return false;
         }
 
@@ -69,7 +69,7 @@ class CRCM_Email_Manager {
     public function send_status_change_notification($booking_id, $new_status, $old_status) {
         $booking = $this->get_booking_data($booking_id);
 
-        if (!$booking || empty($booking['customer_data']['email'])) {
+        if (is_wp_error($booking) || empty($booking['customer_data']['email'])) {
             return false;
         }
 
@@ -138,7 +138,7 @@ class CRCM_Email_Manager {
     public function send_pickup_reminder($booking_id) {
         $booking = $this->get_booking_data($booking_id);
 
-        if (!$booking || empty($booking['customer_data']['email'])) {
+        if (is_wp_error($booking) || empty($booking['customer_data']['email'])) {
             return false;
         }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Plugin Tests">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>
+

--- a/tests/BookingManagerTest.php
+++ b/tests/BookingManagerTest.php
@@ -1,0 +1,44 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class BookingManagerTest extends TestCase {
+    protected $manager;
+
+    protected function setUp(): void {
+        $this->manager = new CRCM_Booking_Manager();
+    }
+
+    public function test_create_booking_invalid_vehicle_returns_wp_error() {
+        $result = $this->manager->create_booking(array(
+            'vehicle_id' => 0,
+            'pickup_date' => '2024-01-01',
+            'return_date' => '2024-01-02',
+            'customer_data' => array(
+                'first_name' => 'John',
+                'last_name'  => 'Doe',
+                'email'      => 'john@example.com',
+            ),
+        ));
+        $this->assertTrue(is_wp_error($result));
+    }
+
+    public function test_create_booking_invalid_dates_returns_wp_error() {
+        $result = $this->manager->create_booking(array(
+            'vehicle_id' => 1,
+            'pickup_date' => '2024-01-05',
+            'return_date' => '2024-01-01',
+            'customer_data' => array(
+                'first_name' => 'John',
+                'last_name'  => 'Doe',
+                'email'      => 'john@example.com',
+            ),
+        ));
+        $this->assertTrue(is_wp_error($result));
+    }
+
+    public function test_get_booking_invalid_id_returns_wp_error() {
+        $result = $this->manager->get_booking(0);
+        $this->assertTrue(is_wp_error($result));
+    }
+}
+

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+define('ABSPATH', __DIR__ . '/../');
+
+require_once __DIR__ . '/wp-stubs.php';
+require_once __DIR__ . '/../inc/class-booking-manager.php';
+

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -1,0 +1,69 @@
+<?php
+if (!class_exists('WP_Error')) {
+    class WP_Error {
+        public $errors = array();
+
+        public function __construct($code = '', $message = '') {
+            if ($code) {
+                $this->errors[$code][] = $message;
+            }
+        }
+
+        public function get_error_message($code = '') {
+            if ($code && isset($this->errors[$code][0])) {
+                return $this->errors[$code][0];
+            }
+
+            $messages = array();
+            foreach ($this->errors as $error) {
+                $messages[] = $error[0];
+            }
+            return implode(', ', $messages);
+        }
+    }
+}
+
+if (!function_exists('is_wp_error')) {
+    function is_wp_error($thing) {
+        return $thing instanceof WP_Error;
+    }
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = null) {
+        return $text;
+    }
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($str) {
+        return filter_var($str, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+    }
+}
+
+if (!function_exists('sanitize_email')) {
+    function sanitize_email($email) {
+        return filter_var($email, FILTER_SANITIZE_EMAIL);
+    }
+}
+
+if (!function_exists('sanitize_textarea_field')) {
+    function sanitize_textarea_field($str) {
+        return trim($str);
+    }
+}
+
+if (!function_exists('is_email')) {
+    function is_email($email) {
+        return filter_var($email, FILTER_VALIDATE_EMAIL);
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action() {}
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter() {}
+}
+


### PR DESCRIPTION
## Summary
- implement `create_booking` and `get_booking` with sanitization, validation, and WP_Error responses
- propagate WP_Error handling to API endpoints, customer portal, and email manager
- add PHPUnit tests for booking validation

## Testing
- `php -l inc/class-booking-manager.php`
- `php -l inc/class-api-endpoints.php`
- `php -l inc/class-customer-portal.php`
- `php -l inc/class-email-manager.php`
- `php -l tests/BookingManagerTest.php`
- `php -l tests/bootstrap.php`
- `php -l tests/wp-stubs.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689525ceacb08333be1f1ef7c89ab3e6