### PR TITLE
Add WP_Query pagination and filtering for vehicle search

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -51,7 +51,7 @@
             const $button = $form.find('.crcm-search-btn');
             const $results = $('#crcm-search-results');
 
-            const perPage = 6;
+            const perPage = parseInt($form.data('per-page'), 10) || 6;
             const formData = {
                 action: 'crcm_search_vehicles',
                 nonce: crcm_ajax.nonce,

--- a/inc/class-api-endpoints.php
+++ b/inc/class-api-endpoints.php
@@ -50,6 +50,14 @@ class CRCM_API_Endpoints {
                     'required' => false,
                     'type'     => 'integer',
                 ),
+                'posts_per_page' => array(
+                    'required' => false,
+                    'type'     => 'integer',
+                ),
+                'page' => array(
+                    'required' => false,
+                    'type'     => 'integer',
+                ),
             ),
         ) );
 

--- a/inc/class-vehicle-manager.php
+++ b/inc/class-vehicle-manager.php
@@ -1545,6 +1545,10 @@ class CRCM_Vehicle_Manager {
                 $vehicle_data[$key] = sanitize_text_field($value);
             }
             update_post_meta($post_id, '_crcm_vehicle_data', $vehicle_data);
+
+            if (isset($vehicle_data['vehicle_type'])) {
+                update_post_meta($post_id, '_crcm_vehicle_type', $vehicle_data['vehicle_type']);
+            }
         }
         
         // Save pricing data
@@ -1921,17 +1925,21 @@ class CRCM_Vehicle_Manager {
             'fields'         => 'ids',
         );
 
-        $query           = new WP_Query($args);
-        $vehicle_ids     = $query->posts;
-        $available_vehicles = array();
+        if (!empty($vehicle_type)) {
+            $args['meta_query'] = array(
+                array(
+                    'key'   => '_crcm_vehicle_type',
+                    'value' => $vehicle_type,
+                ),
+            );
+        }
+
+        $query               = new WP_Query($args);
+        $vehicle_ids         = $query->posts;
+        $available_vehicles  = array();
 
         foreach ($vehicle_ids as $vehicle_id) {
             $vehicle_data = get_post_meta($vehicle_id, '_crcm_vehicle_data', true);
-
-            // Filter by type if specified
-            if (!empty($vehicle_type) && isset($vehicle_data['vehicle_type']) && $vehicle_data['vehicle_type'] !== $vehicle_type) {
-                continue;
-            }
 
             $available_quantity = $this->check_availability($vehicle_id, $pickup_date, $return_date);
             $pricing_data       = get_post_meta($vehicle_id, '_crcm_pricing_data', true);

--- a/templates/frontend/search-form.php
+++ b/templates/frontend/search-form.php
@@ -21,7 +21,7 @@ $locations = crcm_get_locations();
             <p><?php _e('Trova il veicolo perfetto per la tua vacanza in pochi click.', 'custom-rental-manager'); ?></p>
         </div>
         
-        <form id="crcm-vehicle-search" class="crcm-search-form">
+        <form id="crcm-vehicle-search" class="crcm-search-form" data-per-page="6">
             <div class="crcm-search-fields">
                 <!-- Date Fields Row -->
                 <div class="crcm-field-row">


### PR DESCRIPTION
## Summary
- persist vehicle type meta for efficient lookups
- filter vehicle search with WP_Query and support pagination args
- expose pagination parameters to REST route and frontend form

## Testing
- `php -l inc/class-vehicle-manager.php`
- `php -l inc/class-api-endpoints.php`
- `php -l templates/frontend/search-form.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6895400e28a08333967297034444ff6e