### PR TITLE
Use 'paged' parameter for vehicle pagination

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -46,7 +46,7 @@
         },
 
         // Search vehicles via AJAX
-        searchVehicles: function(page = 1) {
+        searchVehicles: function(paged = 1) {
             const $form = $('#crcm-vehicle-search');
             const $button = $form.find('.crcm-search-btn');
             const $results = $('#crcm-search-results');
@@ -60,7 +60,7 @@
                 vehicle_type: $('#vehicle_type').val(),
                 pickup_location: $('#pickup_location').val(),
                 posts_per_page: perPage,
-                page: page
+                paged: paged
             };
 
             // Validate dates
@@ -126,8 +126,8 @@
         initPagination: function() {
             $(document).on('click', '.crcm-page-link', function(e) {
                 e.preventDefault();
-                const page = $(this).data('page');
-                CRCM.searchVehicles(page);
+                const paged = $(this).data('page');
+                CRCM.searchVehicles(paged);
             });
         },
 

--- a/inc/class-api-endpoints.php
+++ b/inc/class-api-endpoints.php
@@ -54,7 +54,7 @@ class CRCM_API_Endpoints {
                     'required' => false,
                     'type'     => 'integer',
                 ),
-                'page' => array(
+                'paged' => array(
                     'required' => false,
                     'type'     => 'integer',
                 ),
@@ -169,7 +169,7 @@ class CRCM_API_Endpoints {
         if ($pickup_date && $return_date) {
             $vehicle_type   = $request->get_param('vehicle_type');
             $posts_per_page = $request->get_param('posts_per_page') ? absint($request->get_param('posts_per_page')) : 10;
-            $paged          = $request->get_param('page') ? absint($request->get_param('page')) : 1;
+            $paged          = $request->get_param('paged') ? absint($request->get_param('paged')) : 1;
 
             $vehicles = $vehicle_manager->search_available_vehicles(
                 $pickup_date,

--- a/inc/class-vehicle-manager.php
+++ b/inc/class-vehicle-manager.php
@@ -1894,7 +1894,7 @@ class CRCM_Vehicle_Manager {
         $return_date    = sanitize_text_field($_POST['return_date'] ?? '');
         $vehicle_type   = sanitize_text_field($_POST['vehicle_type'] ?? '');
         $posts_per_page = isset($_POST['posts_per_page']) ? absint($_POST['posts_per_page']) : 10;
-        $paged          = isset($_POST['page']) ? absint($_POST['page']) : 1;
+        $paged          = isset($_POST['paged']) ? absint($_POST['paged']) : 1;
 
         if (empty($pickup_date) || empty($return_date)) {
             wp_send_json_error(__('Please select pickup and return dates.', 'custom-rental-manager'));


### PR DESCRIPTION
## Summary
- Standardize pagination parameter to `paged` across AJAX, REST API, and vehicle search handler
- Wire front-end search and pagination controls to send `paged`

## Testing
- `php -l inc/class-vehicle-manager.php`
- `php -l inc/class-api-endpoints.php`
- `node --check assets/js/frontend.js`
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6895426abd4c8333a731647e2e9968ac