### PR TITLE
Move inline admin assets to separate files

### DIFF
--- a/assets/css/admin-roles.css
+++ b/assets/css/admin-roles.css
@@ -1,0 +1,49 @@
+/* Admin role badge styles */
+.crcm-role-badge {
+    display: inline-block;
+    padding: 3px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    line-height: 1.4;
+}
+
+.crcm-role-badge.customer-active {
+    background: #d4edda;
+    color: #155724;
+}
+
+.crcm-role-badge.customer-inactive {
+    background: #f8d7da;
+    color: #721c24;
+}
+
+.crcm-role-badge.manager {
+    background: #cce5ff;
+    color: #004085;
+}
+
+.crcm-role-badge.admin {
+    background: #fff3cd;
+    color: #856404;
+}
+
+.crcm-role-badge.other {
+    background: #e2e3e5;
+    color: #383d41;
+}
+
+/* Users table improvements */
+.users-php .column-crcm_rental_role {
+    width: 150px;
+}
+
+/* User form styles */
+#crcm-customer-fields .form-table {
+    margin-top: 0;
+}
+
+#crcm-customer-fields th {
+    width: 200px;
+}

--- a/assets/css/admin-vehicle-meta.css
+++ b/assets/css/admin-vehicle-meta.css
@@ -1,0 +1,415 @@
+/* Vehicle admin meta boxes styles */
+
+/* General vehicle type selection */
+.crcm-main-table {
+    border-bottom: 1px solid #ddd;
+    margin-bottom: 20px;
+    padding-bottom: 20px;
+}
+
+.crcm-vehicle-type-selector {
+    width: 200px;
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+#crcm-dynamic-fields .form-table {
+    margin-top: 0;
+}
+
+/* Custom rates */
+.crcm-custom-rates {
+    margin-top: 20px;
+    padding: 20px;
+    background: #f9f9f9;
+    border-radius: 5px;
+}
+
+.crcm-custom-rate-row {
+    margin-bottom: 15px;
+    padding: 15px;
+    background: white;
+    border-radius: 5px;
+    border: 1px solid #ddd;
+}
+
+.crcm-custom-rate-row table {
+    margin: 0;
+}
+
+.crcm-custom-rate-row td {
+    padding: 5px;
+    vertical-align: top;
+}
+
+.crcm-custom-rate-row label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 5px;
+}
+
+.crcm-custom-rate-row input,
+.crcm-custom-rate-row select {
+    width: 100%;
+}
+
+/* Features */
+.crcm-features-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 10px;
+}
+
+.crcm-feature-item {
+    padding: 10px;
+    background: #f9f9f9;
+    border-radius: 5px;
+}
+
+.crcm-feature-item label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+}
+
+.crcm-feature-item input[type="checkbox"] {
+    margin-right: 8px;
+}
+
+.crcm-feature-label {
+    font-weight: 500;
+}
+
+/* Availability */
+.crcm-availability-container {
+    padding: 10px 0;
+}
+
+.crcm-availability-rule {
+    margin-bottom: 15px;
+    padding: 15px;
+    background: white;
+    border-radius: 5px;
+    border: 1px solid #ddd;
+}
+
+.crcm-availability-rule table {
+    margin: 0;
+}
+
+.crcm-availability-rule td {
+    padding: 5px;
+    vertical-align: top;
+}
+
+.crcm-availability-rule label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 5px;
+}
+
+.crcm-availability-rule input,
+.crcm-availability-rule select {
+    width: 100%;
+}
+
+#add-availability-rule {
+    margin-top: 10px;
+}
+
+/* Extras */
+.crcm-extras-container {
+    padding: 15px;
+}
+
+.crcm-extra-service-row {
+    margin-bottom: 15px;
+    padding: 15px;
+    background: #f9f9f9;
+    border-radius: 5px;
+    border: 1px solid #ddd;
+}
+
+.crcm-extra-service-row table {
+    margin: 0;
+}
+
+.crcm-extra-service-row td {
+    padding: 5px;
+    vertical-align: top;
+}
+
+.crcm-extra-service-row label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 5px;
+}
+
+.crcm-extra-service-row input {
+    width: 100%;
+}
+
+.crcm-extra-service-row .description {
+    margin-top: 5px;
+    font-size: 12px;
+    color: #666;
+}
+
+#add-extra-service {
+    margin-top: 10px;
+}
+
+/* Insurance */
+.crcm-insurance-container {
+    padding: 15px;
+}
+
+.crcm-insurance-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+}
+
+.crcm-insurance-card {
+    border: 2px solid #ddd;
+    border-radius: 8px;
+    background: white;
+    overflow: hidden;
+}
+
+.crcm-basic-card {
+    border-color: #27ae60;
+}
+
+.crcm-premium-card {
+    border-color: #3498db;
+}
+
+.card-header {
+    background: #f8f9fa;
+    padding: 15px;
+    border-bottom: 1px solid #ddd;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.crcm-basic-card .card-header {
+    background: #27ae60;
+    color: white;
+}
+
+.crcm-premium-card .card-header {
+    background: #3498db;
+    color: white;
+}
+
+.card-header h3 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.status-badge {
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.status-included {
+    background: rgba(255,255,255,0.2);
+    color: white;
+}
+
+.card-content {
+    padding: 15px;
+}
+
+.features-list h4,
+.cost-info h4 {
+    margin: 0 0 10px 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: #333;
+}
+
+.features-list ul {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.features-list li {
+    margin-bottom: 5px;
+    font-size: 13px;
+}
+
+.cost-display {
+    text-align: center;
+    padding: 10px;
+}
+
+.cost-amount {
+    font-size: 18px;
+    font-weight: 700;
+}
+
+.cost-amount.included {
+    color: #27ae60;
+}
+
+.cost-input {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.cost-input input {
+    flex: 1;
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+.currency {
+    font-weight: 600;
+    color: #666;
+}
+
+.card-content .description {
+    margin-top: 5px;
+    font-size: 12px;
+    color: #666;
+}
+
+@media (max-width: 768px) {
+    .crcm-insurance-cards {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Misc */
+.crcm-misc-container {
+    padding: 15px;
+}
+
+.crcm-misc-sections {
+    display: grid;
+    gap: 25px;
+}
+
+.crcm-misc-section {
+    background: #f9f9f9;
+    border-radius: 8px;
+    padding: 20px;
+    border: 1px solid #ddd;
+}
+
+.crcm-misc-section h3 {
+    margin: 0 0 15px 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: #333;
+    border-bottom: 2px solid #ddd;
+    padding-bottom: 8px;
+}
+
+.crcm-misc-section .form-table {
+    margin: 0;
+}
+
+.crcm-misc-section .form-table th {
+    width: 200px;
+    padding: 10px 0;
+    font-weight: 600;
+}
+
+.crcm-misc-section .form-table td {
+    padding: 10px 0;
+}
+
+.crcm-misc-section input[type="number"],
+.crcm-misc-section select {
+    width: 100px;
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+.crcm-misc-section input[type="checkbox"] {
+    margin-right: 8px;
+}
+
+.crcm-misc-section .description {
+    margin-top: 5px;
+    font-size: 12px;
+    color: #666;
+    font-style: italic;
+}
+
+.crcm-misc-section label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+/* Special styling for featured section */
+.crcm-misc-section:last-child {
+    border-color: #f39c12;
+    background: linear-gradient(135deg, #fff9e6 0%, #fff 100%);
+}
+
+.crcm-misc-section:last-child h3 {
+    color: #f39c12;
+    border-color: #f39c12;
+}
+
+/* Vehicle badges on list tables */
+.crcm-type-badge {
+    display: inline-block;
+    padding: 3px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: white;
+}
+
+.crcm-type-auto {
+    background: #667eea;
+}
+
+.crcm-type-scooter {
+    background: #764ba2;
+}
+
+.crcm-extras-count {
+    background: #27ae60;
+    color: white;
+    padding: 2px 6px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.crcm-no-extras {
+    color: #999;
+    font-style: italic;
+}
+
+.crcm-featured-badge {
+    background: #f39c12;
+    color: white;
+    padding: 2px 6px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.crcm-not-featured {
+    color: #999;
+}

--- a/assets/js/admin-vehicle-meta.js
+++ b/assets/js/admin-vehicle-meta.js
@@ -1,0 +1,133 @@
+(function($){
+    'use strict';
+    $(function(){
+        // Dynamic fields based on vehicle type
+        $('#vehicle_type').on('change', function(){
+            const vehicleType = $(this).val();
+            $.post(crcm_admin.ajax_url, {
+                action: 'crcm_get_vehicle_fields',
+                vehicle_type: vehicleType,
+                nonce: crcm_admin.nonce
+            }, function(response){
+                if(response.success){
+                    $('#crcm-dynamic-fields').html(response.data);
+                    $('#crcm-dynamic-fields').trigger('vehicle_type_changed', [vehicleType]);
+                }
+            });
+        });
+
+        // Custom rates
+        const ratesContainer = $('#custom-rates-container');
+        let rateIndex = parseInt(ratesContainer.data('rate-index'), 10) || 0;
+        $('#add-custom-rate').on('click', function(){
+            const template = $('#crcm-custom-rate-template').html().replace(/__INDEX__/g, rateIndex);
+            ratesContainer.append(template);
+            rateIndex++;
+        });
+        $(document).on('click', '.remove-rate', function(){
+            $(this).closest('.crcm-custom-rate-row').remove();
+        });
+        $(document).on('change', '.rate-type-selector', function(){
+            const $row = $(this).closest('.crcm-custom-rate-row');
+            const type = $(this).val();
+            if(type === 'weekends'){
+                $row.find('.date-fields').hide();
+            } else {
+                $row.find('.date-fields').show();
+            }
+        });
+
+        // Features update
+        $(document).on('vehicle_type_changed', '#crcm-dynamic-fields', function(e, vehicleType){
+            updateFeatures(vehicleType);
+        });
+
+        function updateFeatures(vehicleType){
+            $.post(crcm_admin.ajax_url, {
+                action: 'crcm_get_vehicle_features',
+                vehicle_type: vehicleType,
+                nonce: crcm_admin.nonce
+            }, function(response){
+                if(response.success){
+                    $('#crcm-features-container .crcm-features-grid').html(response.data);
+                    $('#crcm-features-container').attr('data-vehicle-type', vehicleType);
+                }
+            });
+        }
+
+        // Availability rules
+        const availabilityContainer = $('#availability-rules-container');
+        let ruleIndex = parseInt(availabilityContainer.data('rule-index'), 10) || 0;
+        const maxQuantity = parseInt(availabilityContainer.data('max-quantity'), 10) || 1;
+        const allLabel = availabilityContainer.data('all-label');
+
+        $('#add-availability-rule').on('click', function(e){
+            e.preventDefault();
+            let quantityOptions = '';
+            for(let i = 1; i <= maxQuantity; i++){
+                quantityOptions += `<option value="${i}">${i}</option>`;
+            }
+            quantityOptions += `<option value="all">${allLabel}</option>`;
+            const template = $('#crcm-availability-rule-template').html()
+                .replace(/__INDEX__/g, ruleIndex)
+                .replace('__QUANTITY_OPTIONS__', quantityOptions);
+            availabilityContainer.append(template);
+            ruleIndex++;
+        });
+
+        $(document).on('click', '.remove-rule', function(e){
+            e.preventDefault();
+            $(this).closest('.crcm-availability-rule').remove();
+        });
+
+        // Extra services
+        const extrasContainer = $('#extras-services-container');
+        let serviceIndex = parseInt(extrasContainer.data('service-index'), 10) || 0;
+
+        $('#add-extra-service').on('click', function(e){
+            e.preventDefault();
+            const template = $('#crcm-extra-service-template').html().replace(/__INDEX__/g, serviceIndex);
+            extrasContainer.append(template);
+            serviceIndex++;
+        });
+
+        $(document).on('click', '.remove-service', function(e){
+            e.preventDefault();
+            $(this).closest('.crcm-extra-service-row').remove();
+        });
+
+        // Misc toggles
+        $('#cancellation_enabled').on('change', function(){
+            if($(this).is(':checked')){
+                $('.cancellation-days-row').show();
+            } else {
+                $('.cancellation-days-row').hide();
+            }
+        });
+
+        $('#late_return_rule').on('change', function(){
+            if($(this).is(':checked')){
+                $('.late-return-time-row').show();
+            } else {
+                $('.late-return-time-row').hide();
+            }
+        });
+
+        $('#featured_vehicle').on('change', function(){
+            if($(this).is(':checked')){
+                $('.featured-priority-row').show();
+            } else {
+                $('.featured-priority-row').hide();
+            }
+        });
+
+        $('#min_rental_days, #max_rental_days').on('change', function(){
+            const minDays = parseInt($('#min_rental_days').val(), 10) || 1;
+            const maxDays = parseInt($('#max_rental_days').val(), 10) || 30;
+            if(minDays > maxDays){
+                alert(crcm_vehicle_meta.min_greater_max);
+                $('#max_rental_days').val(minDays);
+            }
+        });
+    });
+})(jQuery);

--- a/custom-rental-car-manager.php
+++ b/custom-rental-car-manager.php
@@ -621,6 +621,38 @@ class CRCM_Plugin {
             );
         }
 
+        if ( $screen && 'crcm_vehicle' === $screen->post_type ) {
+            $vehicle_css = CRCM_PLUGIN_PATH . 'assets/css/admin-vehicle-meta.css';
+            $vehicle_js  = CRCM_PLUGIN_PATH . 'assets/js/admin-vehicle-meta.js';
+
+            if ( file_exists( $vehicle_css ) ) {
+                wp_enqueue_style(
+                    'crcm-admin-vehicle',
+                    CRCM_PLUGIN_URL . 'assets/css/admin-vehicle-meta.css',
+                    array(),
+                    CRCM_VERSION
+                );
+            }
+
+            if ( file_exists( $vehicle_js ) ) {
+                wp_enqueue_script(
+                    'crcm-admin-vehicle',
+                    CRCM_PLUGIN_URL . 'assets/js/admin-vehicle-meta.js',
+                    array( 'jquery', 'crcm-admin' ),
+                    CRCM_VERSION,
+                    true
+                );
+
+                wp_localize_script(
+                    'crcm-admin-vehicle',
+                    'crcm_vehicle_meta',
+                    array(
+                        'min_greater_max' => __( 'I giorni minimi non possono essere maggiori di quelli massimi', 'custom-rental-manager' ),
+                    )
+                );
+            }
+        }
+
         if ( isset( $_GET['page'] ) && 'crcm-dashboard' === $_GET['page'] ) {
             $dashboard_css = CRCM_PLUGIN_PATH . 'assets/css/admin-dashboard.css';
             if ( file_exists( $dashboard_css ) ) {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1110,61 +1110,21 @@ function crcm_get_next_booking_number() {
 // ===============================================
 
 /**
- * Add admin styles for role badges and interface
+ * Enqueue admin styles for role badges and interface.
+ *
+ * @param string $hook The current admin page hook.
  */
-function crcm_add_admin_role_styles() {
-    ?>
-    <style>
-    /* Role badge styles */
-    .crcm-role-badge {
-        display: inline-block;
-        padding: 3px 8px;
-        border-radius: 12px;
-        font-size: 11px;
-        font-weight: 600;
-        text-transform: uppercase;
-        line-height: 1.4;
+function crcm_enqueue_admin_role_styles( $hook ) {
+    // Load only on user management screens.
+    if ( ! in_array( $hook, array( 'users.php', 'user-edit.php', 'user-new.php', 'profile.php' ), true ) ) {
+        return;
     }
-    
-    .crcm-role-badge.customer-active {
-        background: #d4edda;
-        color: #155724;
-    }
-    
-    .crcm-role-badge.customer-inactive {
-        background: #f8d7da;
-        color: #721c24;
-    }
-    
-    .crcm-role-badge.manager {
-        background: #cce5ff;
-        color: #004085;
-    }
-    
-    .crcm-role-badge.admin {
-        background: #fff3cd;
-        color: #856404;
-    }
-    
-    .crcm-role-badge.other {
-        background: #e2e3e5;
-        color: #383d41;
-    }
-    
-    /* Users table improvements */
-    .users-php .column-crcm_rental_role {
-        width: 150px;
-    }
-    
-    /* User form styles */
-    #crcm-customer-fields .form-table {
-        margin-top: 0;
-    }
-    
-    #crcm-customer-fields th {
-        width: 200px;
-    }
-    </style>
-    <?php
+
+    wp_enqueue_style(
+        'crcm-admin-roles',
+        CRCM_PLUGIN_URL . 'assets/css/admin-roles.css',
+        array(),
+        CRCM_VERSION
+    );
 }
-add_action('admin_head', 'crcm_add_admin_role_styles');
+add_action( 'admin_enqueue_scripts', 'crcm_enqueue_admin_role_styles' );


### PR DESCRIPTION
## Summary
- Extract role management styles into `admin-roles.css` and load only on user screens
- Offload vehicle meta box scripts/styles to dedicated assets with dynamic templates
- Enqueue new admin assets conditionally for `crcm_vehicle` editing

## Testing
- `php -l inc/functions.php`
- `php -l inc/class-vehicle-manager.php`
- `php -l custom-rental-car-manager.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c1b528548333ba5f2a26154397a0