### PR TITLE
Sanitize GET parameters and enforce capability checks

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -229,7 +229,10 @@ function crcm_add_role_filter_links($views) {
     $customer_count = $user_counts['avail_roles']['crcm_customer'] ?? 0;
     $manager_count = $user_counts['avail_roles']['crcm_manager'] ?? 0;
     
-    $current_role = isset($_GET['role']) ? $_GET['role'] : '';
+    $current_role = '';
+    if ( current_user_can( 'manage_options' ) && ! empty( sanitize_text_field( $_GET['role'] ?? '' ) ) ) {
+        $current_role = sanitize_text_field( $_GET['role'] );
+    }
     
     $views['crcm_customer'] = sprintf(
         '<a href="%s" class="%s">%s <span class="count">(%d)</span></a>',

--- a/templates/admin/calendar.php
+++ b/templates/admin/calendar.php
@@ -12,8 +12,14 @@ if (!defined('ABSPATH')) {
 }
 
 // Get current month data
-$current_month = isset($_GET['month']) ? intval($_GET['month']) : date('n');
-$current_year = isset($_GET['year']) ? intval($_GET['year']) : date('Y');
+$month_param = sanitize_text_field( $_GET['month'] ?? '' );
+$year_param  = sanitize_text_field( $_GET['year'] ?? '' );
+$current_month = ( current_user_can( 'manage_options' ) && ! empty( $month_param ) )
+    ? intval( $month_param )
+    : intval( date( 'n' ) );
+$current_year  = ( current_user_can( 'manage_options' ) && ! empty( $year_param ) )
+    ? intval( $year_param )
+    : intval( date( 'Y' ) );
 
 $first_day = mktime(0, 0, 0, $current_month, 1, $current_year);
 $days_in_month = date('t', $first_day);

--- a/templates/frontend/booking-form.php
+++ b/templates/frontend/booking-form.php
@@ -12,11 +12,21 @@ if (!defined('ABSPATH')) {
 }
 
 // Get parameters from URL
-$vehicle_id = isset($_GET['vehicle']) ? intval($_GET['vehicle']) : ($atts['vehicle_id'] ?? '');
-$pickup_date = isset($_GET['pickup_date']) ? sanitize_text_field($_GET['pickup_date']) : '';
-$return_date = isset($_GET['return_date']) ? sanitize_text_field($_GET['return_date']) : '';
-$pickup_time = isset($_GET['pickup_time']) ? sanitize_text_field($_GET['pickup_time']) : '09:00';
-$return_time = isset($_GET['return_time']) ? sanitize_text_field($_GET['return_time']) : '18:00';
+$vehicle_id  = ! empty( sanitize_text_field( $_GET['vehicle'] ?? '' ) )
+    ? intval( sanitize_text_field( $_GET['vehicle'] ) )
+    : ( $atts['vehicle_id'] ?? '' );
+$pickup_date = ! empty( sanitize_text_field( $_GET['pickup_date'] ?? '' ) )
+    ? sanitize_text_field( $_GET['pickup_date'] )
+    : '';
+$return_date = ! empty( sanitize_text_field( $_GET['return_date'] ?? '' ) )
+    ? sanitize_text_field( $_GET['return_date'] )
+    : '';
+$pickup_time = ! empty( sanitize_text_field( $_GET['pickup_time'] ?? '' ) )
+    ? sanitize_text_field( $_GET['pickup_time'] )
+    : '09:00';
+$return_time = ! empty( sanitize_text_field( $_GET['return_time'] ?? '' ) )
+    ? sanitize_text_field( $_GET['return_time'] )
+    : '18:00';
 
 $vehicle = null;
 if ($vehicle_id) {

--- a/templates/frontend/vehicle-list.php
+++ b/templates/frontend/vehicle-list.php
@@ -12,10 +12,18 @@ if (!defined('ABSPATH')) {
 }
 
 // Get search parameters
-$pickup_date = isset($_GET['pickup_date']) ? sanitize_text_field($_GET['pickup_date']) : '';
-$return_date = isset($_GET['return_date']) ? sanitize_text_field($_GET['return_date']) : '';
-$pickup_time = isset($_GET['pickup_time']) ? sanitize_text_field($_GET['pickup_time']) : '09:00';
-$return_time = isset($_GET['return_time']) ? sanitize_text_field($_GET['return_time']) : '18:00';
+$pickup_date = ! empty( sanitize_text_field( $_GET['pickup_date'] ?? '' ) )
+    ? sanitize_text_field( $_GET['pickup_date'] )
+    : '';
+$return_date = ! empty( sanitize_text_field( $_GET['return_date'] ?? '' ) )
+    ? sanitize_text_field( $_GET['return_date'] )
+    : '';
+$pickup_time = ! empty( sanitize_text_field( $_GET['pickup_time'] ?? '' ) )
+    ? sanitize_text_field( $_GET['pickup_time'] )
+    : '09:00';
+$return_time = ! empty( sanitize_text_field( $_GET['return_time'] ?? '' ) )
+    ? sanitize_text_field( $_GET['return_time'] )
+    : '18:00';
 
 // Get vehicle types for filtering
 $vehicle_types = crcm_get_vehicle_types();


### PR DESCRIPTION
## Summary
- Sanitize incoming query parameters in booking form, vehicle list, calendar, and admin role filters
- Gate role-based filtering and calendar navigation behind `current_user_can('manage_options')`

## Testing
- `php -l inc/functions.php`
- `php -l templates/frontend/booking-form.php`
- `php -l templates/admin/calendar.php`
- `php -l templates/frontend/vehicle-list.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68960d88de408333a292289a0e01975d