### PR TITLE
Fire booking status change hook with previous status

### DIFF
--- a/inc/class-booking-manager.php
+++ b/inc/class-booking-manager.php
@@ -111,7 +111,10 @@ class CRCM_Booking_Manager {
         );
         update_post_meta($booking_id, '_crcm_booking_data', $booking_data);
         update_post_meta($booking_id, '_crcm_customer_data', $customer_data);
+
+        $old_status = get_post_meta($booking_id, '_crcm_booking_status', true);
         update_post_meta($booking_id, '_crcm_booking_status', 'pending');
+        do_action('crcm_booking_status_changed', $booking_id, 'pending', $old_status);
 
         return array(
             'booking_id'     => $booking_id,
@@ -1011,7 +1014,10 @@ class CRCM_Booking_Manager {
         
         // Save booking status
         if (isset($_POST['booking_status'])) {
-            update_post_meta($post_id, '_crcm_booking_status', sanitize_text_field($_POST['booking_status']));
+            $old_status = get_post_meta($post_id, '_crcm_booking_status', true);
+            $new_status = sanitize_text_field($_POST['booking_status']);
+            update_post_meta($post_id, '_crcm_booking_status', $new_status);
+            do_action('crcm_booking_status_changed', $post_id, $new_status, $old_status);
         }
         
         // Save notes

--- a/inc/class-customer-portal.php
+++ b/inc/class-customer-portal.php
@@ -73,7 +73,9 @@ class CRCM_Customer_Portal {
         }
 
         // Update booking status
+        $old_status = get_post_meta($booking_id, '_crcm_booking_status', true);
         update_post_meta($booking_id, '_crcm_booking_status', 'cancelled');
+        do_action('crcm_booking_status_changed', $booking_id, 'cancelled', $old_status);
 
         wp_send_json_success(__('Booking cancelled successfully', 'custom-rental-manager'));
     }

--- a/inc/class-payment-manager.php
+++ b/inc/class-payment-manager.php
@@ -61,7 +61,9 @@ class CRCM_Payment_Manager {
             update_post_meta($booking_id, '_crcm_payment_data', $payment_data);
 
             // Update booking status
+            $old_status = get_post_meta($booking_id, '_crcm_booking_status', true);
             update_post_meta($booking_id, '_crcm_booking_status', 'confirmed');
+            do_action('crcm_booking_status_changed', $booking_id, 'confirmed', $old_status);
 
             wp_send_json_success(array(
                 'message' => __('Payment processed successfully', 'custom-rental-manager'),
@@ -104,7 +106,9 @@ class CRCM_Payment_Manager {
 
             if ($refund_amount >= $payment_data['paid_amount']) {
                 $payment_data['payment_status'] = 'refunded';
+                $old_status = get_post_meta($booking_id, '_crcm_booking_status', true);
                 update_post_meta($booking_id, '_crcm_booking_status', 'refunded');
+                do_action('crcm_booking_status_changed', $booking_id, 'refunded', $old_status);
             } else {
                 $payment_data['payment_status'] = 'partial_refund';
             }


### PR DESCRIPTION
## Summary
- fire `crcm_booking_status_changed` whenever a booking's status is updated, passing the previous status

## Testing
- `php -l inc/class-booking-manager.php`
- `php -l inc/class-payment-manager.php`
- `php -l inc/class-customer-portal.php`
- `phpunit`
- `phpcs --standard=WordPress inc/class-booking-manager.php inc/class-payment-manager.php inc/class-customer-portal.php` *(fails: the "WordPress" coding standard is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68961d8f144c8333af538566cbbbd72b