### PR TITLE
Add scheduled status updates and admin notifications

### DIFF
--- a/custom-rental-car-manager.php
+++ b/custom-rental-car-manager.php
@@ -820,6 +820,7 @@ class CRCM_Plugin {
      */
     public static function deactivate() {
         wp_clear_scheduled_hook('crcm_daily_reminder_check');
+        wp_clear_scheduled_hook('crcm_daily_status_check');
         flush_rewrite_rules();
 
         // Optionally remove roles on deactivation (uncomment if needed)

--- a/inc/class-email-manager.php
+++ b/inc/class-email-manager.php
@@ -42,6 +42,8 @@ class CRCM_Email_Manager {
             return false;
         }
 
+        $settings = get_option('crcm_settings', array());
+
         $subject = sprintf(__('Booking Confirmation - %s', 'custom-rental-manager'), $booking['booking_number']);
         $message = $this->get_booking_confirmation_template($booking);
 
@@ -55,6 +57,11 @@ class CRCM_Email_Manager {
             $message,
             $headers
         );
+
+        if (!empty($settings['enable_admin_notifications'])) {
+            $admin_email = !empty($settings['company_email']) ? $settings['company_email'] : get_option('admin_email');
+            wp_mail($admin_email, $subject, $message, $headers);
+        }
 
         if ($sent) {
             update_post_meta($booking_id, '_crcm_confirmation_email_sent', current_time('mysql'));
@@ -73,6 +80,8 @@ class CRCM_Email_Manager {
             return false;
         }
 
+        $settings = get_option('crcm_settings', array());
+
         // Don't send notification for initial status set
         if (empty($old_status)) {
             return false;
@@ -85,12 +94,19 @@ class CRCM_Email_Manager {
             'Content-Type: text/html; charset=UTF-8',
         );
 
-        return wp_mail(
+        $sent = wp_mail(
             $booking['customer_data']['email'],
             $subject,
             $message,
             $headers
         );
+
+        if (!empty($settings['enable_admin_notifications'])) {
+            $admin_email = !empty($settings['company_email']) ? $settings['company_email'] : get_option('admin_email');
+            wp_mail($admin_email, $subject, $message, $headers);
+        }
+
+        return $sent;
     }
 
     /**

--- a/tests/wp-stubs.php
+++ b/tests/wp-stubs.php
@@ -67,3 +67,15 @@ if (!function_exists('add_filter')) {
     function add_filter() {}
 }
 
+if (!function_exists('wp_next_scheduled')) {
+    function wp_next_scheduled($hook) {
+        return false;
+    }
+}
+
+if (!function_exists('wp_schedule_event')) {
+    function wp_schedule_event($timestamp, $recurrence, $hook) {
+        return true;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add daily cron to move confirmed bookings to active and active bookings to completed when dates pass
- fire creation hook for manual bookings so pending quotes email is sent
- notify admin alongside customer on booking confirmations and status changes
- stub WordPress scheduling functions for tests and clear new cron on deactivate

## Testing
- `php -l inc/class-booking-manager.php`
- `php -l inc/class-email-manager.php`
- `php -l custom-rental-car-manager.php`
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68962448bd848333986ef55f2a107987