### PR TITLE
feat: add multilingual email templates

### DIFF
--- a/custom-rental-car-manager.php
+++ b/custom-rental-car-manager.php
@@ -1049,6 +1049,23 @@ class CRCM_Plugin {
             array( 'label_for' => 'enable_admin_notifications', 'type' => 'checkbox' )
         );
 
+        add_settings_field(
+            'booking_confirmation_template',
+            __( 'Booking Confirmation Template', 'custom-rental-manager' ),
+            array( $this, 'render_field' ),
+            'crcm-settings',
+            'crcm_email_section',
+            array( 'label_for' => 'booking_confirmation_template', 'type' => 'text', 'description' => __( 'Template slug for booking confirmations.', 'custom-rental-manager' ) )
+        );
+        add_settings_field(
+            'status_change_template',
+            __( 'Status Change Template', 'custom-rental-manager' ),
+            array( $this, 'render_field' ),
+            'crcm-settings',
+            'crcm_email_section',
+            array( 'label_for' => 'status_change_template', 'type' => 'text', 'description' => __( 'Template slug for status change emails.', 'custom-rental-manager' ) )
+        );
+
         add_settings_section( 'crcm_delivery_section', '', '__return_false', 'crcm-settings' );
         add_settings_field(
             'enable_home_delivery',
@@ -1124,6 +1141,8 @@ class CRCM_Plugin {
         $output['enable_booking_confirmation'] = isset( $input['enable_booking_confirmation'] ) ? 1 : 0;
         $output['enable_pickup_reminder']    = isset( $input['enable_pickup_reminder'] ) ? 1 : 0;
         $output['enable_admin_notifications'] = isset( $input['enable_admin_notifications'] ) ? 1 : 0;
+        $output['booking_confirmation_template'] = sanitize_text_field( $input['booking_confirmation_template'] );
+        $output['status_change_template'] = sanitize_text_field( $input['status_change_template'] );
         $output['enable_home_delivery']      = isset( $input['enable_home_delivery'] ) ? 1 : 0;
         $output['home_delivery_fee']         = floatval( $input['home_delivery_fee'] );
         $output['home_delivery_radius']      = intval( $input['home_delivery_radius'] );
@@ -1212,6 +1231,8 @@ class CRCM_Plugin {
             'enable_booking_confirmation' => 1,
             'enable_pickup_reminder'    => 1,
             'enable_admin_notifications' => 1,
+            'booking_confirmation_template' => 'booking-confirmation',
+            'status_change_template'   => 'status-change',
             'enable_home_delivery'      => 1,
             'home_delivery_fee'         => 25,
             'home_delivery_radius'      => 20,

--- a/inc/class-email-manager.php
+++ b/inc/class-email-manager.php
@@ -45,7 +45,7 @@ class CRCM_Email_Manager {
         $settings = get_option('crcm_settings', array());
 
         $subject = sprintf(__('Booking Confirmation - %s', 'custom-rental-manager'), $booking['booking_number']);
-        $message = $this->get_booking_confirmation_template($booking);
+        $message = $this->get_booking_confirmation_template($booking, 'customer');
 
         $headers = array(
             'Content-Type: text/html; charset=UTF-8',
@@ -59,8 +59,9 @@ class CRCM_Email_Manager {
         );
 
         if (!empty($settings['enable_admin_notifications'])) {
-            $admin_email = !empty($settings['company_email']) ? $settings['company_email'] : get_option('admin_email');
-            wp_mail($admin_email, $subject, $message, $headers);
+            $admin_email   = !empty($settings['company_email']) ? $settings['company_email'] : get_option('admin_email');
+            $admin_message = $this->get_booking_confirmation_template($booking, 'admin');
+            wp_mail($admin_email, $subject, $admin_message, $headers);
         }
 
         if ($sent) {
@@ -88,7 +89,7 @@ class CRCM_Email_Manager {
         }
 
         $subject = sprintf(__('Booking Status Update - %s', 'custom-rental-manager'), $booking['booking_number']);
-        $message = $this->get_status_change_template($booking, $new_status, $old_status);
+        $message = $this->get_status_change_template($booking, $new_status, $old_status, 'customer');
 
         $headers = array(
             'Content-Type: text/html; charset=UTF-8',
@@ -102,8 +103,9 @@ class CRCM_Email_Manager {
         );
 
         if (!empty($settings['enable_admin_notifications'])) {
-            $admin_email = !empty($settings['company_email']) ? $settings['company_email'] : get_option('admin_email');
-            wp_mail($admin_email, $subject, $message, $headers);
+            $admin_email   = !empty($settings['company_email']) ? $settings['company_email'] : get_option('admin_email');
+            $admin_message = $this->get_status_change_template($booking, $new_status, $old_status, 'admin');
+            wp_mail($admin_email, $subject, $admin_message, $headers);
         }
 
         return $sent;
@@ -180,9 +182,19 @@ class CRCM_Email_Manager {
     }
 
     /**
-     * Get booking confirmation email template
+     * Get booking confirmation email template.
+     *
+     * @param array  $booking   Booking data array.
+     * @param string $recipient Recipient type: customer or admin.
+     *
+     * @return string
      */
-    public function get_booking_confirmation_template($booking) {
+    public function get_booking_confirmation_template($booking, $recipient = 'customer') {
+        $settings = get_option('crcm_settings', array());
+        $template = !empty($settings['booking_confirmation_template']) ? $settings['booking_confirmation_template'] : 'booking-confirmation';
+        return $this->render_template($template, $booking, $recipient);
+
+        // Legacy HTML template below retained for reference
         $vehicle = get_post($booking['booking_data']['vehicle_id']);
         $vehicle_name = $vehicle ? $vehicle->post_title : __('Unknown Vehicle', 'custom-rental-manager');
 
@@ -458,9 +470,24 @@ class CRCM_Email_Manager {
     }
 
     /**
-     * Get status change email template
+     * Get status change email template.
+     *
+     * @param array  $booking   Booking data array.
+     * @param string $new_status New status string.
+     * @param string $old_status Previous status string.
+     * @param string $recipient Recipient type: customer or admin.
+     *
+     * @return string
      */
-    public function get_status_change_template($booking, $new_status, $old_status) {
+    public function get_status_change_template($booking, $new_status, $old_status, $recipient = 'customer') {
+        $settings = get_option('crcm_settings', array());
+        $template = !empty($settings['status_change_template']) ? $settings['status_change_template'] : 'status-change';
+        return $this->render_template($template, $booking, $recipient, array(
+            'new_status' => $new_status,
+            'old_status' => $old_status,
+        ));
+
+        // Legacy HTML template below retained for reference
         $vehicle = get_post($booking['booking_data']['vehicle_id']);
         $vehicle_name = $vehicle ? $vehicle->post_title : __('Unknown Vehicle', 'custom-rental-manager');
 
@@ -516,6 +543,45 @@ class CRCM_Email_Manager {
         </html>
         <?php
         return ob_get_clean();
+    }
+
+    /**
+     * Render an email template file.
+     *
+     * @param string $template  Template slug (without extension).
+     * @param array  $booking   Booking data array.
+     * @param string $recipient Recipient type: customer or admin.
+     * @param array  $args      Extra variables for the template.
+     *
+     * @return string
+     */
+    private function render_template($template, $booking, $recipient = 'customer', $args = array()) {
+        $language = $this->get_customer_language($booking['booking_id']);
+        $path     = CRCM_PLUGIN_PATH . 'templates/emails/' . $language . '/' . $recipient . '/' . $template . '.php';
+        if (!file_exists($path)) {
+            $path = CRCM_PLUGIN_PATH . 'templates/emails/en/' . $recipient . '/' . $template . '.php';
+        }
+
+        if (!empty($args)) {
+            extract($args, EXTR_SKIP);
+        }
+
+        ob_start();
+        include $path;
+        return ob_get_clean();
+    }
+
+    /**
+     * Get customer language based on user meta.
+     *
+     * @param int $booking_id Booking ID.
+     *
+     * @return string
+     */
+    private function get_customer_language($booking_id) {
+        $user_id  = (int) get_post_meta($booking_id, '_crcm_customer_user_id', true);
+        $language = $user_id ? get_user_meta($user_id, 'crcm_language', true) : '';
+        return $language ? $language : 'en';
     }
 
     /**

--- a/templates/emails/en/admin/booking-confirmation.php
+++ b/templates/emails/en/admin/booking-confirmation.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Booking confirmation email template for admins (EN)
+ *
+ * Available variables:
+ * - $booking (array)
+ */
+?>
+<!DOCTYPE html>
+<html>
+<body>
+    <p><?php _e('A new booking has been created.', 'custom-rental-manager'); ?></p>
+    <p><?php printf(__('Booking Number: %s', 'custom-rental-manager'), esc_html($booking['booking_number'])); ?></p>
+    <p><?php printf(__('Customer: %s %s', 'custom-rental-manager'), esc_html($booking['customer_data']['first_name']), esc_html($booking['customer_data']['last_name'])); ?></p>
+</body>
+</html>

--- a/templates/emails/en/admin/status-change.php
+++ b/templates/emails/en/admin/status-change.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Booking status change email template for admins (EN)
+ *
+ * Available variables:
+ * - $booking (array)
+ * - $new_status (string)
+ * - $old_status (string)
+ */
+?>
+<!DOCTYPE html>
+<html>
+<body>
+    <p><?php _e('Booking status updated.', 'custom-rental-manager'); ?></p>
+    <p><?php printf(__('Booking Number: %s', 'custom-rental-manager'), esc_html($booking['booking_number'])); ?></p>
+    <p><?php printf(__('Status: %s → %s', 'custom-rental-manager'), esc_html($old_status), esc_html($new_status)); ?></p>
+</body>
+</html>

--- a/templates/emails/en/customer/booking-confirmation.php
+++ b/templates/emails/en/customer/booking-confirmation.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Booking confirmation email template for customers (EN)
+ *
+ * Available variables:
+ * - $booking (array)
+ */
+?>
+<!DOCTYPE html>
+<html>
+<body>
+    <p><?php printf(__('Dear %s,', 'custom-rental-manager'), esc_html($booking['customer_data']['first_name'])); ?></p>
+    <p><?php _e('Thank you for your booking!', 'custom-rental-manager'); ?></p>
+    <p><?php printf(__('Booking Number: %s', 'custom-rental-manager'), esc_html($booking['booking_number'])); ?></p>
+</body>
+</html>

--- a/templates/emails/en/customer/status-change.php
+++ b/templates/emails/en/customer/status-change.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Booking status change email template for customers (EN)
+ *
+ * Available variables:
+ * - $booking (array)
+ * - $new_status (string)
+ */
+?>
+<!DOCTYPE html>
+<html>
+<body>
+    <p><?php printf(__('Dear %s,', 'custom-rental-manager'), esc_html($booking['customer_data']['first_name'])); ?></p>
+    <p><?php printf(__('Your booking status changed to %s.', 'custom-rental-manager'), esc_html($new_status)); ?></p>
+</body>
+</html>

--- a/templates/emails/it/admin/booking-confirmation.php
+++ b/templates/emails/it/admin/booking-confirmation.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Template email conferma prenotazione per admin (IT)
+ *
+ * Variabili disponibili:
+ * - $booking (array)
+ */
+?>
+<!DOCTYPE html>
+<html>
+<body>
+    <p>È stata creata una nuova prenotazione.</p>
+    <p><?php echo 'Numero prenotazione: ' . esc_html($booking['booking_number']); ?></p>
+    <p><?php echo 'Cliente: ' . esc_html($booking['customer_data']['first_name']) . ' ' . esc_html($booking['customer_data']['last_name']); ?></p>
+</body>
+</html>

--- a/templates/emails/it/admin/status-change.php
+++ b/templates/emails/it/admin/status-change.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Template email cambio stato prenotazione per admin (IT)
+ *
+ * Variabili disponibili:
+ * - $booking (array)
+ * - $new_status (string)
+ * - $old_status (string)
+ */
+?>
+<!DOCTYPE html>
+<html>
+<body>
+    <p>Aggiornamento stato prenotazione.</p>
+    <p><?php echo 'Numero prenotazione: ' . esc_html($booking['booking_number']); ?></p>
+    <p><?php echo 'Stato: ' . esc_html($old_status) . ' → ' . esc_html($new_status); ?></p>
+</body>
+</html>

--- a/templates/emails/it/customer/booking-confirmation.php
+++ b/templates/emails/it/customer/booking-confirmation.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Template email conferma prenotazione per clienti (IT)
+ *
+ * Variabili disponibili:
+ * - $booking (array)
+ */
+?>
+<!DOCTYPE html>
+<html>
+<body>
+    <p><?php echo 'Gentile ' . esc_html($booking['customer_data']['first_name']) . ','; ?></p>
+    <p>Grazie per la tua prenotazione!</p>
+    <p><?php echo 'Numero prenotazione: ' . esc_html($booking['booking_number']); ?></p>
+</body>
+</html>

--- a/templates/emails/it/customer/status-change.php
+++ b/templates/emails/it/customer/status-change.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Template email cambio stato prenotazione per clienti (IT)
+ *
+ * Variabili disponibili:
+ * - $booking (array)
+ * - $new_status (string)
+ */
+?>
+<!DOCTYPE html>
+<html>
+<body>
+    <p><?php echo 'Gentile ' . esc_html($booking['customer_data']['first_name']) . ','; ?></p>
+    <p><?php echo 'Lo stato della tua prenotazione è cambiato in ' . esc_html($new_status) . '.'; ?></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add English and Italian email templates for admin and customer notifications
- load email templates based on customer language and selected template slug
- expose template selection fields in Email settings

## Testing
- `php -l inc/class-email-manager.php`
- `php -l custom-rental-car-manager.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689636571bb08333afbc407109b4849d