### PR TITLE
Move vehicle features AJAX hook into manager constructor

### DIFF
--- a/inc/class-vehicle-manager.php
+++ b/inc/class-vehicle-manager.php
@@ -76,6 +76,7 @@ class CRCM_Vehicle_Manager {
 
         // AJAX handlers
         add_action('wp_ajax_crcm_get_vehicle_fields', array($this, 'ajax_get_vehicle_fields'));
+        add_action('wp_ajax_crcm_get_vehicle_features', array($this, 'ajax_get_vehicle_features'));
     }
 
     /**
@@ -1475,6 +1476,3 @@ class CRCM_Vehicle_Manager {
     }
 }
 
-// Add CSS for admin styling
-// Add AJAX handler for features
-add_action('wp_ajax_crcm_get_vehicle_features', array(crcm()->vehicle_manager, 'ajax_get_vehicle_features'));


### PR DESCRIPTION
## Summary
- register `crcm_get_vehicle_features` AJAX handler within `CRCM_Vehicle_Manager` constructor
- remove leftover global AJAX hook at file end

## Testing
- `php -l inc/class-vehicle-manager.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68963a790a8083339d330734f29c7db9