### PR TITLE
feat: expose base and extra daily pricing details

### DIFF
--- a/inc/class-email-manager.php
+++ b/inc/class-email-manager.php
@@ -337,14 +337,14 @@ class CRCM_Email_Manager {
                             <tbody>
                                 <?php foreach ($booking['pricing_breakdown']['line_items'] as $item): ?>
                                     <?php
-                                    $name   = esc_html($item['name'] ?? '');
                                     $qty    = intval($item['qty'] ?? 0);
                                     $amount = floatval($item['amount'] ?? 0);
                                     $free   = !empty($item['free']);
+                                    $label  = crcm_format_line_item_label($item, $currency_symbol);
                                     $amount_display = $free ? __('Free', 'custom-rental-manager') : $currency_symbol . number_format($amount, 2);
                                     ?>
                                     <tr>
-                                        <td><?php echo $name; ?><?php if ($free) : ?> (<?php _e('Included', 'custom-rental-manager'); ?>)<?php endif; ?></td>
+                                        <td><?php echo $label; ?><?php if ($free) : ?> (<?php _e('Included', 'custom-rental-manager'); ?>)<?php endif; ?></td>
                                         <td align="right"><?php echo esc_html($qty); ?></td>
                                         <td align="right"><?php echo esc_html($amount_display); ?></td>
                                     </tr>

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -506,6 +506,44 @@ function crcm_format_price($amount, $currency_symbol = '€') {
 }
 
 /**
+ * Format a pricing line item label for display.
+ *
+ * Adds daily or flat rate indicators and separates base and extra rates.
+ *
+ * @param array  $item            Line item data.
+ * @param string $currency_symbol Currency symbol.
+ * @return string
+ */
+function crcm_format_line_item_label($item, $currency_symbol = '€') {
+    $type       = isset($item['type']) ? $item['type'] : 'flat';
+    $base_rate  = isset($item['base_rate']) ? floatval($item['base_rate']) : 0;
+    $extra_rate = isset($item['extra_rate']) ? floatval($item['extra_rate']) : 0;
+    $name       = sanitize_text_field($item['name'] ?? '');
+
+    if ($extra_rate > 0) {
+        $label  = sprintf(
+            __('Tariffa base %s/giorno', 'custom-rental-manager'),
+            crcm_format_price($base_rate, $currency_symbol)
+        );
+        $label .= '<br>' . sprintf(
+            __('Tariffa aggiuntiva %s/giorno', 'custom-rental-manager'),
+            crcm_format_price($extra_rate, $currency_symbol)
+        );
+        return $label;
+    }
+
+    if ('daily' === $type) {
+        return sprintf(
+            '%s %s/giorno',
+            esc_html($name),
+            crcm_format_price($base_rate, $currency_symbol)
+        );
+    }
+
+    return esc_html($name);
+}
+
+/**
  * Format date according to settings.
  *
  * @param string|int $date   Date string or timestamp.

--- a/templates/emails/en/customer/booking-confirmation.php
+++ b/templates/emails/en/customer/booking-confirmation.php
@@ -19,15 +19,16 @@
         </tr>
     </thead>
     <tbody>
-    <?php foreach ($booking['pricing_breakdown']['line_items'] as $item) { ?>
-        <?php
-        $name          = esc_html($item['name'] ?? '');
+    <?php
+    $currency_symbol = crcm_get_setting('currency_symbol', '€');
+    foreach ($booking['pricing_breakdown']['line_items'] as $item) {
         $amount        = floatval($item['amount'] ?? 0);
         $free          = ! empty($item['free']);
-        $amount_display = $free ? __('Free', 'custom-rental-manager') : '€' . number_format($amount, 2);
+        $label         = crcm_format_line_item_label($item, $currency_symbol);
+        $amount_display = $free ? __('Free', 'custom-rental-manager') : crcm_format_price($amount, $currency_symbol);
         ?>
         <tr>
-            <td><?php echo $name; ?><?php if ($free) { ?> (<?php _e('Included', 'custom-rental-manager'); ?>)<?php } ?></td>
+            <td><?php echo $label; ?><?php if ($free) { ?> (<?php _e('Included', 'custom-rental-manager'); ?>)<?php } ?></td>
             <td align="right"><?php echo esc_html($amount_display); ?></td>
         </tr>
     <?php }
@@ -38,10 +39,11 @@
 ?>
 
 <?php
-$total_amount = $booking['pricing_breakdown']['final_total'] ?? 0;
+$total_amount   = $booking['pricing_breakdown']['final_total'] ?? 0;
+$currency_symbol = crcm_get_setting('currency_symbol', '€');
 ?>
 <p style="font-weight:bold; margin-top:15px;">
-    <?php printf(__('Total: %s', 'custom-rental-manager'), '€' . number_format((float) $total_amount, 2)); ?>
+    <?php printf(__('Total: %s', 'custom-rental-manager'), crcm_format_price((float) $total_amount, $currency_symbol)); ?>
 </p>
 
 <?php if ('pending' === $booking['status']) { ?>

--- a/templates/emails/en/customer/pickup-reminder.php
+++ b/templates/emails/en/customer/pickup-reminder.php
@@ -22,15 +22,16 @@ $pickup_time = $booking['booking_data']['pickup_time'] ?? '';
         </tr>
     </thead>
     <tbody>
-    <?php foreach ($booking['pricing_breakdown']['line_items'] as $item) { ?>
-        <?php
-        $name          = esc_html($item['name'] ?? '');
+    <?php
+    $currency_symbol = crcm_get_setting('currency_symbol', '€');
+    foreach ($booking['pricing_breakdown']['line_items'] as $item) {
         $amount        = floatval($item['amount'] ?? 0);
         $free          = ! empty($item['free']);
-        $amount_display = $free ? __('Free', 'custom-rental-manager') : '€' . number_format($amount, 2);
+        $label         = crcm_format_line_item_label($item, $currency_symbol);
+        $amount_display = $free ? __('Free', 'custom-rental-manager') : crcm_format_price($amount, $currency_symbol);
         ?>
         <tr>
-            <td><?php echo $name; ?><?php if ($free) { ?> (<?php _e('Included', 'custom-rental-manager'); ?>)<?php } ?></td>
+            <td><?php echo $label; ?><?php if ($free) { ?> (<?php _e('Included', 'custom-rental-manager'); ?>)<?php } ?></td>
             <td align="right"><?php echo esc_html($amount_display); ?></td>
         </tr>
     <?php } ?>
@@ -39,10 +40,11 @@ $pickup_time = $booking['booking_data']['pickup_time'] ?? '';
 <?php } ?>
 
 <?php
-$total_amount = $booking['pricing_breakdown']['final_total'] ?? 0;
+$total_amount    = $booking['pricing_breakdown']['final_total'] ?? 0;
+$currency_symbol = crcm_get_setting('currency_symbol', '€');
 ?>
 <p style="font-weight:bold; margin-top:15px;">
-    <?php printf(__('Total: %s', 'custom-rental-manager'), '€' . number_format((float) $total_amount, 2)); ?>
+    <?php printf(__('Total: %s', 'custom-rental-manager'), crcm_format_price((float) $total_amount, $currency_symbol)); ?>
 </p>
 
 <?php if ('pending' === $booking['status']) { ?>

--- a/templates/emails/en/customer/status-change.php
+++ b/templates/emails/en/customer/status-change.php
@@ -27,15 +27,16 @@ $message = $status_messages[$new_status] ?? sprintf(__('Your booking status chan
         </tr>
     </thead>
     <tbody>
-    <?php foreach ($booking['pricing_breakdown']['line_items'] as $item) { ?>
-        <?php
-        $name          = esc_html($item['name'] ?? '');
+    <?php
+    $currency_symbol = crcm_get_setting('currency_symbol', '€');
+    foreach ($booking['pricing_breakdown']['line_items'] as $item) {
         $amount        = floatval($item['amount'] ?? 0);
         $free          = ! empty($item['free']);
-        $amount_display = $free ? __('Free', 'custom-rental-manager') : '€' . number_format($amount, 2);
+        $label         = crcm_format_line_item_label($item, $currency_symbol);
+        $amount_display = $free ? __('Free', 'custom-rental-manager') : crcm_format_price($amount, $currency_symbol);
         ?>
         <tr>
-            <td><?php echo $name; ?><?php if ($free) { ?> (<?php _e('Included', 'custom-rental-manager'); ?>)<?php } ?></td>
+            <td><?php echo $label; ?><?php if ($free) { ?> (<?php _e('Included', 'custom-rental-manager'); ?>)<?php } ?></td>
             <td align="right"><?php echo esc_html($amount_display); ?></td>
         </tr>
     <?php } ?>
@@ -44,10 +45,11 @@ $message = $status_messages[$new_status] ?? sprintf(__('Your booking status chan
 <?php } ?>
 
 <?php
-$total_amount = $booking['pricing_breakdown']['final_total'] ?? 0;
+$total_amount    = $booking['pricing_breakdown']['final_total'] ?? 0;
+$currency_symbol = crcm_get_setting('currency_symbol', '€');
 ?>
 <p style="font-weight:bold; margin-top:15px;">
-    <?php printf(__('Total: %s', 'custom-rental-manager'), '€' . number_format((float) $total_amount, 2)); ?>
+    <?php printf(__('Total: %s', 'custom-rental-manager'), crcm_format_price((float) $total_amount, $currency_symbol)); ?>
 </p>
 
 <?php if ('pending' === $booking['status']) { ?>

--- a/templates/emails/it/customer/booking-confirmation.php
+++ b/templates/emails/it/customer/booking-confirmation.php
@@ -19,15 +19,16 @@
         </tr>
     </thead>
     <tbody>
-    <?php foreach ($booking['pricing_breakdown']['line_items'] as $item) { ?>
-        <?php
-        $name          = esc_html($item['name'] ?? '');
+    <?php
+    $currency_symbol = crcm_get_setting('currency_symbol', '€');
+    foreach ($booking['pricing_breakdown']['line_items'] as $item) {
         $amount        = floatval($item['amount'] ?? 0);
         $free          = ! empty($item['free']);
-        $amount_display = $free ? __('Gratis', 'custom-rental-manager') : '€' . number_format($amount, 2);
+        $label         = crcm_format_line_item_label($item, $currency_symbol);
+        $amount_display = $free ? __('Gratis', 'custom-rental-manager') : crcm_format_price($amount, $currency_symbol);
         ?>
         <tr>
-            <td><?php echo $name; ?><?php if ($free) { ?> (<?php _e('Incluso', 'custom-rental-manager'); ?>)<?php } ?></td>
+            <td><?php echo $label; ?><?php if ($free) { ?> (<?php _e('Incluso', 'custom-rental-manager'); ?>)<?php } ?></td>
             <td align="right"><?php echo esc_html($amount_display); ?></td>
         </tr>
     <?php } ?>
@@ -36,10 +37,11 @@
 <?php } ?>
 
 <?php
-$total_amount = $booking['pricing_breakdown']['final_total'] ?? 0;
+$total_amount    = $booking['pricing_breakdown']['final_total'] ?? 0;
+$currency_symbol = crcm_get_setting('currency_symbol', '€');
 ?>
 <p style="font-weight:bold; margin-top:15px;">
-    <?php printf(__('Totale: %s', 'custom-rental-manager'), '€' . number_format((float) $total_amount, 2)); ?>
+    <?php printf(__('Totale: %s', 'custom-rental-manager'), crcm_format_price((float) $total_amount, $currency_symbol)); ?>
 </p>
 
 <?php if ('pending' === $booking['status']) { ?>

--- a/templates/emails/it/customer/pickup-reminder.php
+++ b/templates/emails/it/customer/pickup-reminder.php
@@ -22,15 +22,16 @@ $pickup_time = $booking['booking_data']['pickup_time'] ?? '';
         </tr>
     </thead>
     <tbody>
-    <?php foreach ($booking['pricing_breakdown']['line_items'] as $item) { ?>
-        <?php
-        $name          = esc_html($item['name'] ?? '');
+    <?php
+    $currency_symbol = crcm_get_setting('currency_symbol', '€');
+    foreach ($booking['pricing_breakdown']['line_items'] as $item) {
         $amount        = floatval($item['amount'] ?? 0);
         $free          = ! empty($item['free']);
-        $amount_display = $free ? __('Gratis', 'custom-rental-manager') : '€' . number_format($amount, 2);
+        $label         = crcm_format_line_item_label($item, $currency_symbol);
+        $amount_display = $free ? __('Gratis', 'custom-rental-manager') : crcm_format_price($amount, $currency_symbol);
         ?>
         <tr>
-            <td><?php echo $name; ?><?php if ($free) { ?> (<?php _e('Incluso', 'custom-rental-manager'); ?>)<?php } ?></td>
+            <td><?php echo $label; ?><?php if ($free) { ?> (<?php _e('Incluso', 'custom-rental-manager'); ?>)<?php } ?></td>
             <td align="right"><?php echo esc_html($amount_display); ?></td>
         </tr>
     <?php } ?>
@@ -39,10 +40,11 @@ $pickup_time = $booking['booking_data']['pickup_time'] ?? '';
 <?php } ?>
 
 <?php
-$total_amount = $booking['pricing_breakdown']['final_total'] ?? 0;
+$total_amount    = $booking['pricing_breakdown']['final_total'] ?? 0;
+$currency_symbol = crcm_get_setting('currency_symbol', '€');
 ?>
 <p style="font-weight:bold; margin-top:15px;">
-    <?php printf(__('Totale: %s', 'custom-rental-manager'), '€' . number_format((float) $total_amount, 2)); ?>
+    <?php printf(__('Totale: %s', 'custom-rental-manager'), crcm_format_price((float) $total_amount, $currency_symbol)); ?>
 </p>
 
 <?php if ('pending' === $booking['status']) { ?>

--- a/templates/emails/it/customer/status-change.php
+++ b/templates/emails/it/customer/status-change.php
@@ -27,15 +27,16 @@ $message = $status_messages[$new_status] ?? sprintf(__('Lo stato della tua preno
         </tr>
     </thead>
     <tbody>
-    <?php foreach ($booking['pricing_breakdown']['line_items'] as $item) { ?>
-        <?php
-        $name          = esc_html($item['name'] ?? '');
+    <?php
+    $currency_symbol = crcm_get_setting('currency_symbol', '€');
+    foreach ($booking['pricing_breakdown']['line_items'] as $item) {
         $amount        = floatval($item['amount'] ?? 0);
         $free          = ! empty($item['free']);
-        $amount_display = $free ? __('Gratis', 'custom-rental-manager') : '€' . number_format($amount, 2);
+        $label         = crcm_format_line_item_label($item, $currency_symbol);
+        $amount_display = $free ? __('Gratis', 'custom-rental-manager') : crcm_format_price($amount, $currency_symbol);
         ?>
         <tr>
-            <td><?php echo $name; ?><?php if ($free) { ?> (<?php _e('Incluso', 'custom-rental-manager'); ?>)<?php } ?></td>
+            <td><?php echo $label; ?><?php if ($free) { ?> (<?php _e('Incluso', 'custom-rental-manager'); ?>)<?php } ?></td>
             <td align="right"><?php echo esc_html($amount_display); ?></td>
         </tr>
     <?php } ?>
@@ -44,10 +45,11 @@ $message = $status_messages[$new_status] ?? sprintf(__('Lo stato della tua preno
 <?php } ?>
 
 <?php
-$total_amount = $booking['pricing_breakdown']['final_total'] ?? 0;
+$total_amount    = $booking['pricing_breakdown']['final_total'] ?? 0;
+$currency_symbol = crcm_get_setting('currency_symbol', '€');
 ?>
 <p style="font-weight:bold; margin-top:15px;">
-    <?php printf(__('Totale: %s', 'custom-rental-manager'), '€' . number_format((float) $total_amount, 2)); ?>
+    <?php printf(__('Totale: %s', 'custom-rental-manager'), crcm_format_price((float) $total_amount, $currency_symbol)); ?>
 </p>
 
 <?php if ('pending' === $booking['status']) { ?>

--- a/templates/frontend/booking-form.php
+++ b/templates/frontend/booking-form.php
@@ -62,7 +62,11 @@ $extras = array(
 );
 
 // Calculate base price
-$base_total = $daily_rate * $rental_days;
+$end_date = new DateTime($pickup_date ?: date('Y-m-d'));
+$end_date->add(new DateInterval('P' . $rental_days . 'D'));
+$base_total_calc = crcm_calculate_vehicle_pricing($vehicle_id, $pickup_date, $end_date->format('Y-m-d'));
+$extra_daily_rate = $rental_days > 0 ? max(0, ($base_total_calc - ($daily_rate * $rental_days)) / $rental_days) : 0;
+$base_total = $base_total_calc;
 ?>
 
 <div class="crcm-booking-container">
@@ -436,10 +440,16 @@ $base_total = $daily_rate * $rental_days;
                     <h4><?php _e('Costi', 'custom-rental-manager'); ?></h4>
                     <div class="crcm-pricing-breakdown">
                         <div class="crcm-price-item">
-                            <span><?php _e('Noleggio base', 'custom-rental-manager'); ?> (<?php echo $rental_days; ?> <?php _e('giorni', 'custom-rental-manager'); ?>)</span>
-                            <span id="base-price"><?php echo crcm_format_price($base_total, $currency_symbol); ?></span>
+                            <span><?php _e('Tariffa base', 'custom-rental-manager'); ?> <?php echo crcm_format_price($daily_rate, $currency_symbol); ?>/<?php _e('giorno', 'custom-rental-manager'); ?></span>
+                            <span id="base-price"><?php echo crcm_format_price($daily_rate * $rental_days, $currency_symbol); ?></span>
                         </div>
-                        
+                        <?php if ($extra_daily_rate > 0) : ?>
+                        <div class="crcm-price-item">
+                            <span><?php _e('Tariffa aggiuntiva', 'custom-rental-manager'); ?> <?php echo crcm_format_price($extra_daily_rate, $currency_symbol); ?>/<?php _e('giorno', 'custom-rental-manager'); ?></span>
+                            <span id="extra-price"><?php echo crcm_format_price($extra_daily_rate * $rental_days, $currency_symbol); ?></span>
+                        </div>
+                        <?php endif; ?>
+
                         <div id="extras-pricing" class="crcm-extras-pricing">
                             <!-- Extras will be added here by JavaScript -->
                         </div>

--- a/templates/frontend/customer-dashboard.php
+++ b/templates/frontend/customer-dashboard.php
@@ -51,6 +51,8 @@ $user_bookings = get_posts(array(
                     $payment_data    = get_post_meta($booking->ID, '_crcm_payment_data', true);
                     $payment_status  = $payment_data['payment_status'] ?? '';
                     $vehicle         = get_post($booking_data['vehicle_id']);
+                    $pricing_breakdown = get_post_meta($booking->ID, '_crcm_pricing_breakdown', true);
+                    $currency_symbol  = crcm_get_setting('currency_symbol', '€');
                 ?>
                     <div class="crcm-booking-item">
                         <div class="crcm-booking-header">
@@ -60,11 +62,25 @@ $user_bookings = get_posts(array(
 
                         <div class="crcm-booking-details">
                             <p><strong><?php _e('Vehicle:', 'custom-rental-manager'); ?></strong> <?php echo $vehicle ? esc_html($vehicle->post_title) : __('Unknown', 'custom-rental-manager'); ?></p>
-                            <p><strong><?php _e('Dates:', 'custom-rental-manager'); ?></strong> 
-                                <?php echo esc_html(crcm_format_date($booking_data['pickup_date'])); ?> - 
+                            <p><strong><?php _e('Dates:', 'custom-rental-manager'); ?></strong>
+                                <?php echo esc_html(crcm_format_date($booking_data['pickup_date'])); ?> -
                                 <?php echo esc_html(crcm_format_date($booking_data['return_date'])); ?>
                             </p>
                             <p><strong><?php _e('Booked:', 'custom-rental-manager'); ?></strong> <?php echo esc_html(crcm_format_date($booking->post_date)); ?></p>
+                            <?php if (!empty($pricing_breakdown['line_items'])) : ?>
+                                <ul class="crcm-price-details">
+                                    <?php foreach ($pricing_breakdown['line_items'] as $item) : ?>
+                                        <?php
+                                        $label  = crcm_format_line_item_label($item, $currency_symbol);
+                                        $amount = crcm_format_price((float) ($item['amount'] ?? 0), $currency_symbol);
+                                        ?>
+                                        <li><?php echo $label; ?> - <?php echo $amount; ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                                <?php if (!empty($pricing_breakdown['final_total'])) : ?>
+                                    <p><strong><?php _e('Totale:', 'custom-rental-manager'); ?></strong> <?php echo crcm_format_price((float) $pricing_breakdown['final_total'], $currency_symbol); ?></p>
+                                <?php endif; ?>
+                            <?php endif; ?>
                         </div>
 
                         <?php if ($booking_status === 'pending' || $booking_status === 'confirmed'): ?>


### PR DESCRIPTION
## Summary
- add helper to render daily and flat line-item rates
- enrich booking pricing with base and extra daily rates
- surface detailed pricing on booking forms, dashboards and emails

## Testing
- `php -l inc/functions.php`
- `php -l inc/class-booking-manager.php`
- `php -l inc/class-email-manager.php`
- `php -l templates/frontend/booking-form.php`
- `php -l templates/frontend/customer-dashboard.php`
- `php -l templates/emails/en/customer/booking-confirmation.php`
- `php -l templates/emails/en/customer/status-change.php`
- `php -l templates/emails/en/customer/pickup-reminder.php`
- `php -l templates/emails/it/customer/booking-confirmation.php`
- `php -l templates/emails/it/customer/status-change.php`
- `php -l templates/emails/it/customer/pickup-reminder.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689714a0962083338f595ec8dbcc136f