### PR TITLE
Lock booking fields and notify on pending updates

### DIFF
--- a/templates/admin/booking-edit.php
+++ b/templates/admin/booking-edit.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Booking edit lock notice and field disabling.
+ *
+ * @package CustomRentalCarManager
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="notice notice-warning">
+    <p><?php esc_html_e('This booking is locked. Only pickup time, pickup location, return location, internal notes and customer notes can be edited.', 'custom-rental-manager'); ?></p>
+</div>
+<script>
+    jQuery(function($){
+        const allowed = ['#pickup_time', '#pickup_location', '#return_location', '#internal_notes', '#booking_notes'];
+        $('#crcm_booking_details :input, #crcm_booking_customer :input, #crcm_booking_vehicle :input, #crcm_booking_pricing :input, #crcm_booking_status :input, #crcm_booking_notes :input').each(function(){
+            const id = '#' + $(this).attr('id');
+            if (allowed.indexOf(id) === -1) {
+                $(this).prop('disabled', true);
+            }
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- Lock editing for confirmed/active bookings and show warning
- Track and email changes for pending bookings

## Testing
- `php -l inc/class-booking-manager.php`
- `php -l templates/admin/booking-edit.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689716fe822c83339d28dfa51eb81f8a