### PR TITLE
Send booking update notifications to customer and admin

### DIFF
--- a/templates/emails/en/admin/booking-updated.php
+++ b/templates/emails/en/admin/booking-updated.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Booking updated email template for admins (EN).
+ *
+ * @var array $booking
+ * @var array $changes
+ */
+?>
+<p><?php _e('A booking has been updated with the following changes:', 'custom-rental-manager'); ?></p>
+<p><strong><?php printf(__('Booking Number: %s', 'custom-rental-manager'), esc_html($booking['booking_number'])); ?></strong></p>
+<ul>
+<?php foreach ($changes as $field => $values) { ?>
+    <li><?php echo esc_html(ucwords(str_replace('_', ' ', $field))); ?>: <?php echo esc_html($values['old']); ?> → <?php echo esc_html($values['new']); ?></li>
+<?php } ?>
+</ul>
+<p><?php printf(__('Customer: %s %s', 'custom-rental-manager'), esc_html($booking['customer_data']['first_name']), esc_html($booking['customer_data']['last_name'])); ?></p>

--- a/templates/emails/en/customer/booking-updated.php
+++ b/templates/emails/en/customer/booking-updated.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Booking updated email template for customers (EN).
+ *
+ * @var array $booking
+ * @var array $customer
+ * @var array $changes
+ */
+?>
+<p><?php printf(__('Dear %s,', 'custom-rental-manager'), esc_html($customer['first_name'])); ?></p>
+<p><?php _e('The details of your booking have been updated:', 'custom-rental-manager'); ?></p>
+<ul>
+<?php foreach ($changes as $field => $values) { ?>
+    <li><?php echo esc_html(ucwords(str_replace('_', ' ', $field))); ?>: <?php echo esc_html($values['old']); ?> → <?php echo esc_html($values['new']); ?></li>
+<?php } ?>
+</ul>
+<p><strong><?php printf(__('Booking Number: %s', 'custom-rental-manager'), esc_html($booking['booking_number'])); ?></strong></p>

--- a/templates/emails/it/admin/booking-updated.php
+++ b/templates/emails/it/admin/booking-updated.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Template email aggiornamento prenotazione per admin (IT).
+ *
+ * @var array $booking
+ * @var array $changes
+ */
+?>
+<p><?php _e('Una prenotazione è stata aggiornata con le seguenti modifiche:', 'custom-rental-manager'); ?></p>
+<p><strong><?php printf(__('Numero di prenotazione: %s', 'custom-rental-manager'), esc_html($booking['booking_number'])); ?></strong></p>
+<ul>
+<?php foreach ($changes as $field => $values) { ?>
+    <li><?php echo esc_html(ucwords(str_replace('_', ' ', $field))); ?>: <?php echo esc_html($values['old']); ?> → <?php echo esc_html($values['new']); ?></li>
+<?php } ?>
+</ul>
+<p><?php printf(__('Cliente: %s %s', 'custom-rental-manager'), esc_html($booking['customer_data']['first_name']), esc_html($booking['customer_data']['last_name'])); ?></p>

--- a/templates/emails/it/customer/booking-updated.php
+++ b/templates/emails/it/customer/booking-updated.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Template email aggiornamento prenotazione per clienti (IT).
+ *
+ * @var array $booking
+ * @var array $customer
+ * @var array $changes
+ */
+?>
+<p><?php printf(__('Caro %s,', 'custom-rental-manager'), esc_html($customer['first_name'])); ?></p>
+<p><?php _e('I dettagli della tua prenotazione sono stati aggiornati:', 'custom-rental-manager'); ?></p>
+<ul>
+<?php foreach ($changes as $field => $values) { ?>
+    <li><?php echo esc_html(ucwords(str_replace('_', ' ', $field))); ?>: <?php echo esc_html($values['old']); ?> → <?php echo esc_html($values['new']); ?></li>
+<?php } ?>
+</ul>
+<p><strong><?php printf(__('Numero di prenotazione: %s', 'custom-rental-manager'), esc_html($booking['booking_number'])); ?></strong></p>


### PR DESCRIPTION
## Summary
- Capture previous booking data and detect changes before saving
- Notify customer and admin of booking updates via new email templates
- Add multi-language "booking-updated" templates for customer and admin

## Testing
- `php -l inc/class-booking-manager.php`
- `php -l inc/class-email-manager.php`
- `php -l templates/emails/en/customer/booking-updated.php`
- `php -l templates/emails/en/admin/booking-updated.php`
- `php -l templates/emails/it/customer/booking-updated.php`
- `php -l templates/emails/it/admin/booking-updated.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68971ba31a048333bcbe024ded621306