### PR TITLE
Add home delivery option with address

### DIFF
--- a/inc/class-email-manager.php
+++ b/inc/class-email-manager.php
@@ -364,6 +364,10 @@ class CRCM_Email_Manager {
                         <p><strong><?php _e('Return Location:', 'custom-rental-manager'); ?></strong> <?php echo esc_html($return_location); ?></p>
                         <?php endif; ?>
 
+                        <?php if (!empty($booking['booking_data']['home_delivery']) && !empty($booking['booking_data']['delivery_address'])) : ?>
+                        <p><strong><?php _e('Delivery Address:', 'custom-rental-manager'); ?></strong> <?php echo esc_html($booking['booking_data']['delivery_address']); ?></p>
+                        <?php endif; ?>
+
                         <p><strong><?php _e('Insurance:', 'custom-rental-manager'); ?></strong> <?php echo esc_html(ucfirst($booking['booking_data']['insurance_type'])); ?></p>
 
                         <?php if (!empty($booking['booking_data']['extras'])): ?>
@@ -493,6 +497,9 @@ class CRCM_Email_Manager {
                     <p><strong><?php _e('Vehicle:', 'custom-rental-manager'); ?></strong> <?php echo esc_html($vehicle_name); ?></p>
                     <p><strong><?php _e('Pickup:', 'custom-rental-manager'); ?></strong> <?php echo esc_html($booking['booking_data']['pickup_date']); ?> <?php echo esc_html($booking['booking_data']['pickup_time']); ?></p>
                     <p><strong><?php _e('Return:', 'custom-rental-manager'); ?></strong> <?php echo esc_html($booking['booking_data']['return_date']); ?> <?php echo esc_html($booking['booking_data']['return_time']); ?></p>
+                    <?php if (!empty($booking['booking_data']['home_delivery']) && !empty($booking['booking_data']['delivery_address'])) : ?>
+                    <p><strong><?php _e('Delivery Address:', 'custom-rental-manager'); ?></strong> <?php echo esc_html($booking['booking_data']['delivery_address']); ?></p>
+                    <?php endif; ?>
                     <p style="font-size: 18px; font-weight: bold; color: #2563eb;">
                         <strong><?php _e('Total Amount:', 'custom-rental-manager'); ?></strong> <?php echo esc_html($currency_symbol . number_format($total_amount, 2)); ?>
                     </p>
@@ -585,6 +592,9 @@ class CRCM_Email_Manager {
                         <p><strong><?php printf(__('Booking Number: %s', 'custom-rental-manager'), $booking['booking_number']); ?></strong></p>
                         <p><strong><?php printf(__('Vehicle: %s', 'custom-rental-manager'), $vehicle_name); ?></strong></p>
                         <p><strong><?php printf(__('Status: %s', 'custom-rental-manager'), ucfirst($new_status)); ?></strong></p>
+                        <?php if (!empty($booking['booking_data']['home_delivery']) && !empty($booking['booking_data']['delivery_address'])) : ?>
+                        <p><strong><?php _e('Delivery Address:', 'custom-rental-manager'); ?></strong> <?php echo esc_html($booking['booking_data']['delivery_address']); ?></p>
+                        <?php endif; ?>
                     </div>
 
                     <p><?php _e('If you have any questions, please do not hesitate to contact us.', 'custom-rental-manager'); ?></p>

--- a/templates/admin/booking-edit.php
+++ b/templates/admin/booking-edit.php
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 </div>
 <script>
     jQuery(function($){
-        const allowed = ['#pickup_time', '#pickup_location', '#return_location', '#internal_notes', '#booking_notes'];
+        const allowed = ['#pickup_time', '#pickup_location', '#return_location', '#home_delivery', '#delivery_address', '#internal_notes', '#booking_notes'];
         $('#crcm_booking_details :input, #crcm_booking_customer :input, #crcm_booking_vehicle :input, #crcm_booking_pricing :input, #crcm_booking_status :input, #crcm_booking_notes :input').each(function(){
             const id = '#' + $(this).attr('id');
             if (allowed.indexOf(id) === -1) {


### PR DESCRIPTION
## Summary
- add "Consegna a domicilio" checkbox and address field to booking metabox, disabling pickup/drop-off selections when used
- persist delivery address meta and show it in the pricing summary
- include delivery address in confirmation, quote and status change emails

## Testing
- `php -l inc/class-booking-manager.php inc/class-email-manager.php templates/admin/booking-edit.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6897216d224c8333b4bf3cab7e41e8ca