### PR TITLE
Implement pagination for vehicles and calendar

### DIFF
--- a/inc/class-api-endpoints.php
+++ b/inc/class-api-endpoints.php
@@ -75,9 +75,23 @@ class CRCM_API_Endpoints {
 
         register_rest_route('crcm/v1', '/bookings', array(
             array(
-                'methods' => 'GET',
-                'callback' => array($this, 'get_bookings'),
-                'permission_callback' => array($this, 'check_manage_permissions'),
+                'methods'             => 'GET',
+                'callback'            => array( $this, 'get_bookings' ),
+                'permission_callback' => array( $this, 'check_manage_permissions' ),
+                'args'                => array(
+                    'per_page' => array(
+                        'required' => false,
+                        'type'     => 'integer',
+                    ),
+                    'page' => array(
+                        'required' => false,
+                        'type'     => 'integer',
+                    ),
+                    'status' => array(
+                        'required' => false,
+                        'type'     => 'string',
+                    ),
+                ),
             ),
             array(
                 'methods' => 'POST',
@@ -152,6 +166,14 @@ class CRCM_API_Endpoints {
                 'vehicle_id' => array(
                     'required' => false,
                     'type' => 'integer',
+                ),
+                'per_page' => array(
+                    'required' => false,
+                    'type'     => 'integer',
+                ),
+                'page' => array(
+                    'required' => false,
+                    'type'     => 'integer',
                 ),
             ),
         ));
@@ -251,7 +273,11 @@ class CRCM_API_Endpoints {
     }
 
     /**
-     * Get bookings endpoint
+     * Get bookings endpoint.
+     *
+     * @param WP_REST_Request $request Request data.
+     *
+     * @return WP_REST_Response
      */
     public function get_bookings($request) {
         $per_page = $request->get_param( 'per_page' ) ? absint( $request->get_param( 'per_page' ) ) : 20;
@@ -369,14 +395,20 @@ class CRCM_API_Endpoints {
     }
 
     /**
-     * Get calendar endpoint
+     * Get calendar endpoint.
+     *
+     * @param WP_REST_Request $request Request data.
+     *
+     * @return WP_REST_Response
      */
     public function get_calendar($request) {
         $month      = sanitize_text_field( $request->get_param( 'month' ) ?: date( 'Y-m' ) );
         $vehicle_id = absint( $request->get_param( 'vehicle_id' ) ?: 0 );
+        $per_page   = $request->get_param( 'per_page' ) ? absint( $request->get_param( 'per_page' ) ) : 20;
+        $page       = $request->get_param( 'page' ) ? absint( $request->get_param( 'page' ) ) : 1;
 
         $calendar_manager = new CRCM_Calendar_Manager();
-        $calendar_data    = $calendar_manager->get_calendar_data( $month, $vehicle_id );
+        $calendar_data    = $calendar_manager->get_calendar_data( $month, $vehicle_id, $per_page, $page );
 
         return new WP_REST_Response( $calendar_data, 200 );
     }


### PR DESCRIPTION
## Summary
- paginate frontend vehicle list and render navigation links
- add pagination support to calendar queries and REST/AJAX endpoints
- allow bookings and calendar API routes to accept `per_page` and `page`

## Testing
- `php -l templates/frontend/vehicle-list.php`
- `php -l inc/class-calendar-manager.php`
- `php -l inc/class-api-endpoints.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b2c6ee984833394d394ee99c0907f