### PR TITLE
Add pagination support for vehicle listings and bookings

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -46,7 +46,7 @@
         },
 
         // Search vehicles via AJAX
-        searchVehicles: function(paged = 1) {
+        searchVehicles: function(page = 1) {
             const $form = $('#crcm-vehicle-search');
             const $button = $form.find('.crcm-search-btn');
             const $results = $('#crcm-search-results');
@@ -59,8 +59,8 @@
                 return_date: $('#return_date').val(),
                 vehicle_type: $('#vehicle_type').val(),
                 pickup_location: $('#pickup_location').val(),
-                posts_per_page: perPage,
-                paged: paged
+                per_page: perPage,
+                page: page
             };
 
             // Validate dates
@@ -126,8 +126,8 @@
         initPagination: function() {
             $(document).on('click', '.crcm-page-link', function(e) {
                 e.preventDefault();
-                const paged = $(this).data('page');
-                CRCM.searchVehicles(paged);
+                const page = $(this).data('page');
+                CRCM.searchVehicles(page);
             });
         },
 

--- a/inc/class-api-endpoints.php
+++ b/inc/class-api-endpoints.php
@@ -300,18 +300,31 @@ class CRCM_API_Endpoints {
             );
         }
 
-        $posts = get_posts($args);
+        $query    = new WP_Query( $args );
+        $posts    = $query->posts;
         $bookings = array();
 
-        foreach ($posts as $post) {
+        foreach ( $posts as $post ) {
             $booking_manager = crcm()->booking_manager;
-            $booking = $booking_manager->get_booking($post->ID);
-            if (!is_wp_error($booking)) {
+            $booking         = $booking_manager->get_booking( $post->ID );
+            if ( ! is_wp_error( $booking ) ) {
                 $bookings[] = $booking;
             }
         }
 
-        return new WP_REST_Response($bookings, 200);
+        $pagination = array(
+            'current'  => $page,
+            'total'    => (int) $query->max_num_pages,
+            'per_page' => $per_page,
+        );
+
+        return new WP_REST_Response(
+            array(
+                'bookings'   => $bookings,
+                'pagination' => $pagination,
+            ),
+            200
+        );
     }
 
     /**

--- a/inc/class-calendar-manager.php
+++ b/inc/class-calendar-manager.php
@@ -49,11 +49,11 @@ class CRCM_Calendar_Manager {
      * @param string $month      Month in 'Y-m' format.
      * @param int    $vehicle_id Optional vehicle ID filter.
      * @param int    $per_page   Number of bookings per page.
-     * @param int    $paged      Current page number.
+     * @param int    $page       Current page number.
      *
      * @return array{events: array, pagination: array} Calendar events and pagination info.
      */
-    public function get_calendar_data( $month, $vehicle_id = 0, $per_page = 20, $paged = 1 ) {
+    public function get_calendar_data( $month, $vehicle_id = 0, $per_page = 20, $page = 1 ) {
         $start_date = $month . '-01';
         $end_date   = date( 'Y-m-t', strtotime( $start_date ) );
 
@@ -62,7 +62,7 @@ class CRCM_Calendar_Manager {
             'post_type'      => 'crcm_booking',
             'post_status'    => array( 'publish', 'private' ),
             'posts_per_page' => $per_page,
-            'paged'          => $paged,
+            'paged'          => $page,
             'meta_query'     => array(
                 'relation' => 'AND',
                 array(
@@ -127,7 +127,7 @@ class CRCM_Calendar_Manager {
         }
 
         $pagination = array(
-            'current'   => $paged,
+            'current'   => $page,
             'total'     => (int) $query->max_num_pages,
             'per_page'  => $per_page,
         );
@@ -207,11 +207,11 @@ class CRCM_Calendar_Manager {
      *
      * @param int $days     Number of days to look ahead.
      * @param int $per_page Number of bookings per page.
-     * @param int $paged    Current page number.
+     * @param int $page     Current page number.
      *
      * @return array
      */
-    public function get_upcoming_bookings( $days = 7, $per_page = 20, $paged = 1 ) {
+    public function get_upcoming_bookings( $days = 7, $per_page = 20, $page = 1 ) {
         $start_date = date( 'Y-m-d' );
         $end_date   = date( 'Y-m-d', strtotime( '+' . $days . ' days' ) );
 
@@ -219,7 +219,7 @@ class CRCM_Calendar_Manager {
             'post_type'      => 'crcm_booking',
             'post_status'    => array( 'publish', 'private' ),
             'posts_per_page' => $per_page,
-            'paged'          => $paged,
+            'paged'          => $page,
             'meta_query'     => array(
                 array(
                     'key'     => '_crcm_pickup_date',
@@ -247,18 +247,18 @@ class CRCM_Calendar_Manager {
      * Get vehicles out today.
      *
      * @param int $per_page Number of bookings per page.
-     * @param int $paged    Current page number.
+     * @param int $page     Current page number.
      *
      * @return array
      */
-    public function get_vehicles_out_today( $per_page = 20, $paged = 1 ) {
+    public function get_vehicles_out_today( $per_page = 20, $page = 1 ) {
         $today = date( 'Y-m-d' );
 
         $args = array(
             'post_type'      => 'crcm_booking',
             'post_status'    => array( 'publish', 'private' ),
             'posts_per_page' => $per_page,
-            'paged'          => $paged,
+            'paged'          => $page,
             'meta_query'     => array(
                 array(
                     'key'     => '_crcm_pickup_date',
@@ -283,18 +283,18 @@ class CRCM_Calendar_Manager {
      * Get vehicles returning today.
      *
      * @param int $per_page Number of bookings per page.
-     * @param int $paged    Current page number.
+     * @param int $page     Current page number.
      *
      * @return array
      */
-    public function get_vehicles_returning_today( $per_page = 20, $paged = 1 ) {
+    public function get_vehicles_returning_today( $per_page = 20, $page = 1 ) {
         $today = date( 'Y-m-d' );
 
         $args = array(
             'post_type'      => 'crcm_booking',
             'post_status'    => array( 'publish', 'private' ),
             'posts_per_page' => $per_page,
-            'paged'          => $paged,
+            'paged'          => $page,
             'meta_query'     => array(
                 array(
                     'key'     => '_crcm_return_date',

--- a/inc/class-vehicle-manager.php
+++ b/inc/class-vehicle-manager.php
@@ -1362,15 +1362,15 @@ class CRCM_Vehicle_Manager {
 
         $pickup_date    = sanitize_text_field($_POST['pickup_date'] ?? '');
         $return_date    = sanitize_text_field($_POST['return_date'] ?? '');
-        $vehicle_type   = sanitize_text_field($_POST['vehicle_type'] ?? '');
-        $posts_per_page = isset($_POST['posts_per_page']) ? absint($_POST['posts_per_page']) : 10;
-        $paged          = isset($_POST['paged']) ? absint($_POST['paged']) : 1;
+        $vehicle_type = sanitize_text_field($_POST['vehicle_type'] ?? '');
+        $per_page     = isset($_POST['per_page']) ? absint($_POST['per_page']) : 10;
+        $page         = isset($_POST['page']) ? absint($_POST['page']) : 1;
 
         if (empty($pickup_date) || empty($return_date)) {
             wp_send_json_error(__('Please select pickup and return dates.', 'custom-rental-manager'));
         }
 
-        $results = $this->search_available_vehicles($pickup_date, $return_date, $vehicle_type, $posts_per_page, $paged);
+        $results = $this->search_available_vehicles($pickup_date, $return_date, $vehicle_type, $per_page, $page);
 
         wp_send_json_success($results);
     }
@@ -1378,22 +1378,22 @@ class CRCM_Vehicle_Manager {
     /**
      * Search available vehicles with featured priority
      *
-     * @param string $pickup_date    Pickup date.
-     * @param string $return_date    Return date.
-     * @param string $vehicle_type   Optional vehicle type filter.
-     * @param int    $posts_per_page Number of posts per page.
-     * @param int    $paged          Current page number.
+     * @param string $pickup_date  Pickup date.
+     * @param string $return_date  Return date.
+     * @param string $vehicle_type Optional vehicle type filter.
+     * @param int    $per_page     Number of vehicles per page.
+     * @param int    $page         Current page number.
      *
      * @return array
      */
-    public function search_available_vehicles($pickup_date, $return_date, $vehicle_type = '', $posts_per_page = 10, $paged = 1) {
-        $args = array(
-            'post_type'      => 'crcm_vehicle',
-            'post_status'    => 'publish',
-            'posts_per_page' => $posts_per_page,
-            'paged'          => $paged,
-            'fields'         => 'ids',
-        );
+      public function search_available_vehicles($pickup_date, $return_date, $vehicle_type = '', $per_page = 10, $page = 1) {
+          $args = array(
+              'post_type'      => 'crcm_vehicle',
+              'post_status'    => 'publish',
+              'posts_per_page' => $per_page,
+              'paged'          => $page,
+              'fields'         => 'ids',
+          );
 
         if (!empty($vehicle_type)) {
             $args['meta_query'] = array(
@@ -1467,10 +1467,11 @@ class CRCM_Vehicle_Manager {
         });
 
         return array(
-            'vehicles'    => $available_vehicles,
-            'pagination'  => array(
-                'current' => $paged,
-                'total'   => (int) $query->max_num_pages,
+            'vehicles'   => $available_vehicles,
+            'pagination' => array(
+                'current'  => $page,
+                'total'    => (int) $query->max_num_pages,
+                'per_page' => $per_page,
             ),
         );
     }

--- a/templates/frontend/vehicle-list.php
+++ b/templates/frontend/vehicle-list.php
@@ -30,7 +30,7 @@ $vehicle_types = crcm_get_vehicle_types();
 
 // Pagination parameters
 $per_page = isset( $_GET['per_page'] ) ? absint( $_GET['per_page'] ) : 10;
-$paged    = isset( $_GET['page'] ) ? absint( $_GET['page'] ) : 1;
+$page     = isset( $_GET['page'] ) ? absint( $_GET['page'] ) : 1;
 
 // Get vehicles with pagination
 $args = array(
@@ -39,7 +39,7 @@ $args = array(
     'posts_per_page' => $per_page,
     'orderby'        => 'title',
     'order'          => 'ASC',
-    'paged'          => $paged,
+    'paged'          => $page,
 );
 
 $query    = new WP_Query( $args );
@@ -330,7 +330,7 @@ if ($pickup_date && $return_date) {
                 array(
                     'base'      => add_query_arg( 'page', '%#%' ),
                     'format'    => '',
-                    'current'   => $paged,
+                    'current'   => $page,
                     'total'     => (int) $query->max_num_pages,
                     'add_args'  => $add_args,
                     'prev_text' => __( '&laquo; Precedente', 'custom-rental-manager' ),


### PR DESCRIPTION
## Summary
- paginate vehicle list template and expose per_page/page query vars
- allow AJAX vehicle search and REST bookings endpoints to accept per_page and page
- wire up frontend JS pagination controls for vehicles

## Testing
- `php -l inc/class-vehicle-manager.php`
- `php -l inc/class-api-endpoints.php`
- `php -l inc/class-calendar-manager.php`
- `php -l templates/frontend/vehicle-list.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b329aa638833394ab89ac8bc80f3b