### PR TITLE
Ensure unique booking numbers and add collision test

### DIFF
--- a/inc/class-booking-manager.php
+++ b/inc/class-booking-manager.php
@@ -180,7 +180,10 @@ class CRCM_Booking_Manager {
         }
 
         $booking_number = crcm_get_next_booking_number();
-        update_post_meta($booking_id, '_crcm_booking_number', $booking_number);
+        if ( crcm_booking_number_exists( $booking_number ) ) {
+            return new WP_Error( 'duplicate_booking_number', __( 'Booking number collision, please try again', 'custom-rental-manager' ) );
+        }
+        update_post_meta( $booking_id, '_crcm_booking_number', $booking_number );
 
         $booking_data = array(
             'vehicle_id'      => $vehicle_id,

--- a/tests/BookingNumberTest.php
+++ b/tests/BookingNumberTest.php
@@ -1,0 +1,37 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class BookingNumberTest extends TestCase {
+    protected function setUp(): void {
+        global $wpdb;
+        $wpdb = new class() {
+            public $postmeta = 'wp_postmeta';
+            public $data     = array();
+            public function prepare( $query, $value ) {
+                return $value;
+            }
+            public function get_var( $value ) {
+                foreach ( $this->data as $meta ) {
+                    if ( $meta === $value ) {
+                        return 1;
+                    }
+                }
+                return null;
+            }
+        };
+    }
+
+    public function test_collision_generates_unique_number() {
+        global $wpdb;
+        $wpdb->data[] = 'CBR000';
+
+        $generator = static function () {
+            static $calls = 0;
+            $calls++;
+            return ( 1 === $calls ) ? 'CBR000' : 'CBR001';
+        };
+
+        $number = crcm_get_next_booking_number( $generator );
+        $this->assertSame( 'CBR001', $number );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,5 +2,6 @@
 define('ABSPATH', __DIR__ . '/../');
 
 require_once __DIR__ . '/wp-stubs.php';
+require_once __DIR__ . '/../inc/functions.php';
 require_once __DIR__ . '/../inc/class-booking-manager.php';
 


### PR DESCRIPTION
## Summary
- replace sequential booking numbers with prefix-based `uniqid`
- verify booking number uniqueness before saving
- add unit test covering booking number collisions

## Testing
- `php -l inc/functions.php`
- `php -l inc/class-booking-manager.php`
- `php -l tests/bootstrap.php`
- `php -l tests/BookingNumberTest.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b364ea38c8333a8199cdac102ba3f