### PR TITLE
Expand booking pricing breakdown with extras and penalties

### DIFF
--- a/assets/js/admin-booking.js
+++ b/assets/js/admin-booking.js
@@ -359,6 +359,8 @@ jQuery(document).ready(function ($) {
         let lineItems = [];
 
         const baseDailyRate = rentalDays ? baseTotal / rentalDays : 0;
+        const baseRate = vehicleData && vehicleData.pricing ? parseFloat(vehicleData.pricing.daily_rate) || 0 : 0;
+        const extraDaily = baseDailyRate > baseRate ? baseDailyRate - baseRate : 0;
         if (lateReturnApplied && rentalDays > 1) {
             const baseDays = rentalDays - 1;
             if (baseDays > 0) {
@@ -366,21 +368,30 @@ jQuery(document).ready(function ($) {
                     name: i18n.base_rate,
                     qty: baseDays,
                     amount: baseDailyRate * baseDays,
-                    free: false
+                    free: false,
+                    type: 'daily',
+                    base_rate: baseRate,
+                    extra_rate: extraDaily
                 });
             }
             lineItems.push({
                 name: i18n.late_return_fee,
                 qty: 1,
                 amount: baseDailyRate,
-                free: false
+                free: false,
+                type: 'flat',
+                base_rate: baseDailyRate,
+                extra_rate: 0
             });
         } else {
             lineItems.push({
                 name: i18n.base_rate,
                 qty: rentalDays,
                 amount: baseTotal,
-                free: false
+                free: false,
+                type: 'daily',
+                base_rate: baseRate,
+                extra_rate: extraDaily
             });
         }
 
@@ -393,7 +404,10 @@ jQuery(document).ready(function ($) {
                 name: name,
                 qty: rentalDays,
                 amount: amount,
-                free: rate === 0
+                free: rate === 0,
+                type: 'daily',
+                base_rate: rate,
+                extra_rate: 0
             });
         });
 
@@ -406,14 +420,20 @@ jQuery(document).ready(function ($) {
                 name: i18n.premium_insurance,
                 qty: rentalDays,
                 amount: insuranceTotal,
-                free: false
+                free: false,
+                type: 'daily',
+                base_rate: rate,
+                extra_rate: 0
             });
         } else {
             lineItems.push({
                 name: i18n.basic_insurance,
                 qty: rentalDays,
                 amount: 0,
-                free: true
+                free: true,
+                type: 'daily',
+                base_rate: 0,
+                extra_rate: 0
             });
         }
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -515,26 +515,31 @@ function crcm_format_price($amount, $currency_symbol = '€') {
  * @return string
  */
 function crcm_format_line_item_label($item, $currency_symbol = '€') {
+    $name       = sanitize_text_field($item['name'] ?? '');
+    $qty        = isset($item['qty']) ? intval($item['qty']) : 0;
     $type       = isset($item['type']) ? $item['type'] : 'flat';
     $base_rate  = isset($item['base_rate']) ? floatval($item['base_rate']) : 0;
     $extra_rate = isset($item['extra_rate']) ? floatval($item['extra_rate']) : 0;
-    $name       = sanitize_text_field($item['name'] ?? '');
 
-    if ($extra_rate > 0) {
-        $label  = sprintf(
-            __('Tariffa base %s/giorno', 'custom-rental-manager'),
-            crcm_format_price($base_rate, $currency_symbol)
+    if ('daily' === $type) {
+        $day_label = __('day', 'custom-rental-manager');
+        $label     = sprintf(
+            '%s × %d (%s/%s',
+            esc_html($name),
+            $qty,
+            crcm_format_price($base_rate, $currency_symbol),
+            $day_label
         );
-        $label .= '<br>' . sprintf(
-            __('Tariffa aggiuntiva %s/giorno', 'custom-rental-manager'),
-            crcm_format_price($extra_rate, $currency_symbol)
-        );
+        if ($extra_rate > 0) {
+            $label .= ' +' . crcm_format_price($extra_rate, $currency_symbol) . '/' . $day_label;
+        }
+        $label .= ')';
         return $label;
     }
 
-    if ('daily' === $type) {
+    if ($base_rate > 0) {
         return sprintf(
-            '%s %s/giorno',
+            '%s (%s)',
             esc_html($name),
             crcm_format_price($base_rate, $currency_symbol)
         );


### PR DESCRIPTION
## Summary
- build pricing line items for late return fees, extras, insurance, and penalties
- format line item labels with quantity and base/extra rates for email summaries
- record base and extra rates in admin booking line item calculations

## Testing
- `php -l inc/class-booking-manager.php`
- `php -l inc/functions.php`
- `npx eslint assets/js/admin-booking.js` *(fails: ESLint couldn't find a config file)*
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b39e035188333b0dbfafccf0dc0f4