### PR TITLE
Store pricing breakdown line items and show quantities in emails

### DIFF
--- a/templates/emails/en/customer/booking-confirmation.php
+++ b/templates/emails/en/customer/booking-confirmation.php
@@ -15,6 +15,7 @@
     <thead>
         <tr>
             <th align="left"><?php _e('Item', 'custom-rental-manager'); ?></th>
+            <th align="right"><?php _e('Qty', 'custom-rental-manager'); ?></th>
             <th align="right"><?php _e('Amount', 'custom-rental-manager'); ?></th>
         </tr>
     </thead>
@@ -25,10 +26,12 @@
         $amount        = floatval($item['amount'] ?? 0);
         $free          = ! empty($item['free']);
         $label         = crcm_format_line_item_label($item, $currency_symbol);
+        $qty           = intval($item['qty'] ?? 0);
         $amount_display = $free ? __('Free', 'custom-rental-manager') : crcm_format_price($amount, $currency_symbol);
         ?>
         <tr>
             <td><?php echo $label; ?><?php if ($free) { ?> (<?php _e('Included', 'custom-rental-manager'); ?>)<?php } ?></td>
+            <td align="right"><?php echo esc_html($qty); ?></td>
             <td align="right"><?php echo esc_html($amount_display); ?></td>
         </tr>
     <?php }

--- a/templates/emails/it/customer/booking-confirmation.php
+++ b/templates/emails/it/customer/booking-confirmation.php
@@ -15,6 +15,7 @@
     <thead>
         <tr>
             <th align="left"><?php _e('Voce', 'custom-rental-manager'); ?></th>
+            <th align="right"><?php _e('Qty', 'custom-rental-manager'); ?></th>
             <th align="right"><?php _e('Importo', 'custom-rental-manager'); ?></th>
         </tr>
     </thead>
@@ -25,10 +26,12 @@
         $amount        = floatval($item['amount'] ?? 0);
         $free          = ! empty($item['free']);
         $label         = crcm_format_line_item_label($item, $currency_symbol);
+        $qty           = intval($item['qty'] ?? 0);
         $amount_display = $free ? __('Gratis', 'custom-rental-manager') : crcm_format_price($amount, $currency_symbol);
         ?>
         <tr>
             <td><?php echo $label; ?><?php if ($free) { ?> (<?php _e('Incluso', 'custom-rental-manager'); ?>)<?php } ?></td>
+            <td align="right"><?php echo esc_html($qty); ?></td>
             <td align="right"><?php echo esc_html($amount_display); ?></td>
         </tr>
     <?php } ?>


### PR DESCRIPTION
## Summary
- calculate pricing breakdown during booking creation, saving line items including penalties and free flags
- sanitize stored booking data when retrieving bookings
- display line item quantities in confirmation emails for English and Italian templates

## Testing
- `php -l inc/class-booking-manager.php`
- `php -l templates/emails/en/customer/booking-confirmation.php`
- `php -l templates/emails/it/customer/booking-confirmation.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b3becb7fc83339c3b9ad889b32a73