### PR TITLE
Optimize booking queries and add monthly slot caching

### DIFF
--- a/inc/class-api-endpoints.php
+++ b/inc/class-api-endpoints.php
@@ -312,6 +312,7 @@ class CRCM_API_Endpoints {
             'post_status'    => array( 'publish', 'private' ),
             'posts_per_page' => $per_page,
             'paged'          => $page,
+            'fields'         => 'ids',
         );
 
         // Add filters if provided
@@ -324,13 +325,13 @@ class CRCM_API_Endpoints {
             );
         }
 
-        $query    = new WP_Query( $args );
-        $posts    = $query->posts;
-        $bookings = array();
+        $query       = new WP_Query( $args );
+        $booking_ids = $query->posts;
+        $bookings    = array();
 
-        foreach ( $posts as $post ) {
+        foreach ( $booking_ids as $booking_id ) {
             $booking_manager = crcm()->booking_manager;
-            $booking         = $booking_manager->get_booking( $post->ID );
+            $booking         = $booking_manager->get_booking( $booking_id );
             if ( ! is_wp_error( $booking ) ) {
                 $bookings[] = $booking;
             }

--- a/inc/class-calendar-manager.php
+++ b/inc/class-calendar-manager.php
@@ -58,7 +58,7 @@ class CRCM_Calendar_Manager {
         $end_date   = date( 'Y-m-t', strtotime( $start_date ) );
 
         $cache_key = 'crcm_calendar_' . md5( $month . '_' . $vehicle_id . '_' . $per_page . '_' . $page );
-        $cached    = wp_cache_get( $cache_key, 'crcm_calendar' );
+        $cached    = get_transient( $cache_key );
         if ( false !== $cached ) {
             return $cached;
         }
@@ -144,7 +144,7 @@ class CRCM_Calendar_Manager {
             'pagination' => $pagination,
         );
 
-        wp_cache_set( $cache_key, $result, 'crcm_calendar', DAY_IN_SECONDS );
+        set_transient( $cache_key, $result, MONTH_IN_SECONDS );
 
         return $result;
     }


### PR DESCRIPTION
## Summary
- Retrieve only booking IDs before loading details
- Cache monthly calendar results via transients

## Testing
- `php -l inc/class-api-endpoints.php`
- `php -l inc/class-calendar-manager.php`
- `php /usr/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b46cf85c48333ab8d625d52c97c89