### PR TITLE
Add daily booking status cron and notifications

### DIFF
--- a/inc/class-booking-manager.php
+++ b/inc/class-booking-manager.php
@@ -40,10 +40,10 @@ class CRCM_Booking_Manager {
         add_filter('manage_crcm_booking_posts_columns', array($this, 'booking_columns'));
         add_action('manage_crcm_booking_posts_custom_column', array($this, 'booking_column_content'), 10, 2);
 
-        // Booking status scheduler
+        // Daily booking status scheduler
         add_action('crcm_booking_status_check', array($this, 'process_scheduled_statuses'));
         if (!wp_next_scheduled('crcm_booking_status_check')) {
-            wp_schedule_event(time(), 'hourly', 'crcm_booking_status_check');
+            wp_schedule_event(time(), 'daily', 'crcm_booking_status_check');
         }
 
         add_action('admin_notices', array($this, 'render_booking_lock_notice'));
@@ -53,8 +53,9 @@ class CRCM_Booking_Manager {
     /**
      * Process booking status transitions on scheduled event.
      *
-     * Activates confirmed bookings whose pickup time has passed and
-     * completes active bookings whose return time has passed.
+     * Activates confirmed bookings whose pickup time has passed,
+     * completes active bookings whose return time has passed,
+     * and cancels pending bookings whose pickup time has passed.
      *
      * @return void
      */

--- a/inc/class-email-manager.php
+++ b/inc/class-email-manager.php
@@ -105,13 +105,13 @@ class CRCM_Email_Manager {
     }
 
     /**
-     * Send booking status change notification.
+     * Send booking status change notification to customer and admin.
      *
-     * @param int    $booking_id  Booking ID.
-     * @param string $new_status  New booking status.
-     * @param string $old_status  Previous booking status.
+     * @param int    $booking_id Booking ID.
+     * @param string $new_status New booking status.
+     * @param string $old_status Previous booking status.
      *
-     * @return bool Whether the notification was sent.
+     * @return bool Whether the customer notification was sent.
      */
     public function send_status_change_notification($booking_id, $new_status, $old_status) {
         if ($new_status === $old_status) {
@@ -147,11 +147,9 @@ class CRCM_Email_Manager {
             $headers
         );
 
-        if (!empty($settings['enable_admin_notifications'])) {
-            $admin_email   = !empty($settings['company_email']) ? $settings['company_email'] : get_option('admin_email');
-            $admin_message = $this->get_status_change_template($booking, $new_status, $old_status, 'admin');
-            wp_mail($admin_email, $subject, $admin_message, $headers);
-        }
+        $admin_email   = !empty($settings['company_email']) ? $settings['company_email'] : get_option('admin_email');
+        $admin_message = $this->get_status_change_template($booking, $new_status, $old_status, 'admin');
+        wp_mail($admin_email, $subject, $admin_message, $headers);
 
         if ($switched) {
             restore_previous_locale();


### PR DESCRIPTION
## Summary
- schedule daily booking status checks
- email admin and customer on any booking status changes

## Testing
- `php -l inc/class-booking-manager.php`
- `php -l inc/class-email-manager.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b5523b3348333a4c66a73ebc8a2b6