### PR TITLE
feat: add preferred language locale support

### DIFF
--- a/custom-rental-car-manager.php
+++ b/custom-rental-car-manager.php
@@ -60,6 +60,7 @@ class CRCM_Plugin {
     public $payment_manager;
     public $api_endpoints;
     public $customer_portal;
+    public $locale_manager;
 
     /**
      * Get single instance.
@@ -158,7 +159,8 @@ class CRCM_Plugin {
             'class-email-manager.php',
             'class-payment-manager.php',
             'class-api-endpoints.php',
-            'class-customer-portal.php'
+            'class-customer-portal.php',
+            'class-locale-manager.php'
         );
         
         foreach ($classes as $class_file) {
@@ -203,6 +205,10 @@ class CRCM_Plugin {
         
         if (class_exists('CRCM_Customer_Portal')) {
             $this->customer_portal = new CRCM_Customer_Portal();
+        }
+
+        if (class_exists('CRCM_Locale_Manager')) {
+            $this->locale_manager = new CRCM_Locale_Manager();
         }
     }
     

--- a/inc/class-email-manager.php
+++ b/inc/class-email-manager.php
@@ -681,7 +681,15 @@ class CRCM_Email_Manager {
      */
     private function get_customer_language($booking_id) {
         $user_id  = (int) get_post_meta($booking_id, '_crcm_customer_user_id', true);
-        $language = $user_id ? get_user_meta($user_id, 'crcm_language', true) : '';
+        $language = '';
+        if ( $user_id ) {
+            $language = get_user_meta( $user_id, 'crcm_preferred_language', true );
+        }
+        if ( ! $language ) {
+            $customer_data = get_post_meta( $booking_id, '_crcm_customer_data', true );
+            $language      = $customer_data['preferred_language'] ?? '';
+        }
+
         return $language ? $language : 'en';
     }
 

--- a/inc/class-locale-manager.php
+++ b/inc/class-locale-manager.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Locale Manager Class
+ *
+ * Handles switching the WordPress locale based on user preference.
+ *
+ * @package CustomRentalCarManager
+ */
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Locale manager responsible for setting locale from user meta.
+ */
+class CRCM_Locale_Manager
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        add_filter('locale', array( $this, 'set_user_locale' ));
+    }
+
+    /**
+     * Filter the site locale using the user's preferred language.
+     *
+     * @param string $locale Default WordPress locale.
+     * @return string Adjusted locale.
+     */
+    public function set_user_locale($locale)
+    {
+        if (function_exists('is_user_logged_in') && is_user_logged_in()) {
+            $preferred = get_user_meta(get_current_user_id(), 'crcm_preferred_language', true);
+            if ('it' === $preferred) {
+                return 'it_IT';
+            }
+            if ('en' === $preferred) {
+                return 'en_US';
+            }
+        }
+        return $locale;
+    }
+}

--- a/tests/LocaleManagerTest.php
+++ b/tests/LocaleManagerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../inc/class-locale-manager.php';
+
+// Stub WordPress functions used by CRCM_Locale_Manager.
+function is_user_logged_in()
+{
+    return ! empty($GLOBALS['__test_logged_in']);
+}
+
+function get_current_user_id()
+{
+    return $GLOBALS['__test_user_id'] ?? 0;
+}
+
+function get_user_meta($user_id, $key, $single = true)
+{
+    return $GLOBALS['__test_user_meta'][ $user_id ][ $key ] ?? '';
+}
+
+function update_user_meta($user_id, $key, $value)
+{
+    $GLOBALS['__test_user_meta'][ $user_id ][ $key ] = $value;
+}
+
+class LocaleManagerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['__test_user_meta'] = array();
+        $GLOBALS['__test_logged_in'] = true;
+        $GLOBALS['__test_user_id']   = 1;
+    }
+
+    public function testSetUserLocaleUsesPreference()
+    {
+        update_user_meta(1, 'crcm_preferred_language', 'it');
+        $manager = new CRCM_Locale_Manager();
+        $this->assertSame('it_IT', $manager->set_user_locale('en_US'));
+
+        update_user_meta(1, 'crcm_preferred_language', 'en');
+        $this->assertSame('en_US', $manager->set_user_locale('it_IT'));
+    }
+
+    public function testSetUserLocaleFallbacksToDefault()
+    {
+        $manager = new CRCM_Locale_Manager();
+        $this->assertSame('en_US', $manager->set_user_locale('en_US'));
+    }
+}


### PR DESCRIPTION
## Summary
- add locale manager to switch UI language from user preference
- use `crcm_preferred_language` when selecting email templates
- cover locale handling with PHPUnit tests

## Testing
- `phpunit`
- `phpcs --standard=PSR12 inc/class-locale-manager.php inc/class-email-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_689b682ffc5483338dd36ff3e3a4b633