### PR TITLE
Add search form and top rented vehicles to front page

### DIFF
--- a/costabilerent-theme/front-page.php
+++ b/costabilerent-theme/front-page.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Front Page Template
+ *
+ * @package Costabilerent Theme
+ */
+
+get_header();
+?>
+
+<div class="crcm-search-wrapper">
+    <?php echo do_shortcode('[crcm_search_form]'); ?>
+</div>
+
+<?php
+// Get top rented vehicles from last 30 days.
+$bookings = get_posts(
+    array(
+        'post_type'      => 'crcm_booking',
+        'post_status'    => 'publish',
+        'posts_per_page' => -1,
+        'date_query'     => array(
+            array(
+                'after' => date('Y-m-d', strtotime('-30 days')),
+            ),
+        ),
+        'fields'         => 'ids',
+    )
+);
+
+$vehicle_counts = array();
+
+foreach ($bookings as $booking_id) {
+    $booking_data = get_post_meta($booking_id, '_crcm_booking_data', true);
+
+    if (isset($booking_data['vehicle_id'])) {
+        $vehicle_id = absint($booking_data['vehicle_id']);
+        if (! isset($vehicle_counts[ $vehicle_id ])) {
+            $vehicle_counts[ $vehicle_id ] = 0;
+        }
+        $vehicle_counts[ $vehicle_id ]++;
+    }
+}
+
+arsort($vehicle_counts);
+$top_vehicle_ids = array_slice(array_keys($vehicle_counts), 0, 4);
+
+if ($top_vehicle_ids) :
+    ?>
+    <div class="crcm-top-vehicles">
+        <?php
+        foreach ($top_vehicle_ids as $vehicle_id) :
+            $vehicle = get_post($vehicle_id);
+            if (! $vehicle || 'crcm_vehicle' !== $vehicle->post_type) {
+                continue;
+            }
+
+            $title        = get_the_title($vehicle_id);
+            $image        = get_the_post_thumbnail(
+                $vehicle_id,
+                'medium',
+                array('class' => 'crcm-top-vehicles__image')
+            );
+            $seats        = get_post_meta($vehicle_id, '_crcm_seats', true);
+            $transmission = get_post_meta($vehicle_id, '_crcm_transmission', true);
+            $rate         = get_post_meta($vehicle_id, '_crcm_daily_rate', true);
+            ?>
+            <div class="crcm-top-vehicles__card">
+                <?php if ($image) : ?>
+                    <div class="crcm-top-vehicles__thumb">
+                        <?php echo $image; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                    </div>
+                <?php endif; ?>
+                <div class="crcm-top-vehicles__content">
+                    <h3 class="crcm-top-vehicles__title"><?php echo esc_html($title); ?></h3>
+                    <p class="crcm-top-vehicles__meta">
+                        <?php echo esc_html($transmission); ?> |
+                        <?php echo esc_html($seats); ?>
+                        <?php echo esc_html__('Seats', 'custom-rental-manager'); ?>
+                    </p>
+                    <p class="crcm-top-vehicles__rate">
+                        <?php echo esc_html(sprintf('€%s/%s', $rate, __('day', 'custom-rental-manager'))); ?>
+                    </p>
+                </div>
+            </div>
+            <?php
+        endforeach;
+        ?>
+    </div>
+<?php endif; ?>
+
+<?php
+get_footer();
+

--- a/costabilerent-theme/style.css
+++ b/costabilerent-theme/style.css
@@ -11,3 +11,40 @@ Text Domain: costabilerent
 body {
     font-family: sans-serif;
 }
+
+.crcm-top-vehicles {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 20px;
+    margin-top: 2rem;
+}
+
+.crcm-top-vehicles__card {
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #fff;
+}
+
+.crcm-top-vehicles__thumb img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.crcm-top-vehicles__content {
+    padding: 1rem;
+    text-align: center;
+}
+
+.crcm-top-vehicles__title {
+    font-size: 1.125rem;
+    margin: 0 0 0.5rem;
+}
+
+.crcm-top-vehicles__meta,
+.crcm-top-vehicles__rate {
+    margin: 0;
+    font-size: 0.875rem;
+}
+


### PR DESCRIPTION
## Summary
- Include `[crcm_search_form]` shortcode in the front-page template
- Display top 3–4 most rented vehicles from last 30 days with responsive non-clickable cards

## Testing
- `phpcs --standard=PSR12 costabilerent-theme/front-page.php costabilerent-theme/style.css`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b6c428d608333a94ca866fa3f643b