### PR TITLE
Add search results page with AJAX vehicle listing filters

### DIFF
--- a/assets/js/frontend-vehicle-list.js
+++ b/assets/js/frontend-vehicle-list.js
@@ -1,9 +1,9 @@
 jQuery(document).ready(function($) {
     // Vehicle type filter
-    $('#vehicle-type-filter').on('change', function() {
+    $(document).on('change', '#vehicle-type-filter', function() {
         const selectedType = $(this).val();
         const $cards = $('.crcm-vehicle-card');
-        
+
         if (selectedType === '') {
             $cards.show();
         } else {
@@ -16,32 +16,69 @@ jQuery(document).ready(function($) {
                 }
             });
         }
-        
+
         updateResultsCount();
     });
-    
+
+    // Location filter
+    $(document).on('change', '#location-filter', function() {
+        const selectedLocation = $(this).val();
+        const $cards = $('.crcm-vehicle-card');
+
+        if (selectedLocation === '') {
+            $cards.show();
+        } else {
+            $cards.each(function() {
+                const cardLocation = $(this).data('location');
+                if (cardLocation === selectedLocation) {
+                    $(this).show();
+                } else {
+                    $(this).hide();
+                }
+            });
+        }
+
+        updateResultsCount();
+    });
+
     // Price sorting
-    $('#price-sort-filter').on('change', function() {
+    $(document).on('change', '#price-sort-filter', function() {
         const sortType = $(this).val();
         const $grid = $('#vehicles-grid');
         const $cards = $('.crcm-vehicle-card').toArray();
-        
+
         if (sortType === 'price-asc' || sortType === 'price-desc') {
             $cards.sort(function(a, b) {
                 const priceA = parseFloat($(a).data('daily-rate'));
                 const priceB = parseFloat($(b).data('daily-rate'));
-                
+
                 if (sortType === 'price-asc') {
                     return priceA - priceB;
                 } else {
                     return priceB - priceA;
                 }
             });
-            
+
             $grid.empty().append($cards);
         }
     });
-    
+
+    // AJAX pagination
+    $(document).on('click', '.crcm-pagination a', function(e) {
+        e.preventDefault();
+        const url = $(this).attr('href');
+
+        $.get(url, function(response) {
+            const $html = $('<div>').html(response);
+            const $content = $html.find('.crcm-vehicle-list-container').html();
+            $('.crcm-vehicle-list-container').html($content);
+
+            $('#vehicle-type-filter').trigger('change');
+            $('#location-filter').trigger('change');
+            updateResultsCount();
+        });
+    });
+
     // Book now button click
     $(document).on('click', '.crcm-book-now', function() {
         const vehicleId = $(this).data('vehicle-id');
@@ -49,7 +86,7 @@ jQuery(document).ready(function($) {
         const returnDate = $(this).data('return-date');
         const pickupTime = $(this).data('pickup-time');
         const returnTime = $(this).data('return-time');
-        
+
         // Build booking URL with parameters
         const bookingUrl = new URL(window.location.origin + '/booking-form/');
         bookingUrl.searchParams.set('vehicle', vehicleId);
@@ -57,10 +94,10 @@ jQuery(document).ready(function($) {
         bookingUrl.searchParams.set('return_date', returnDate);
         bookingUrl.searchParams.set('pickup_time', pickupTime);
         bookingUrl.searchParams.set('return_time', returnTime);
-        
+
         window.location.href = bookingUrl.toString();
     });
-    
+
     // Update results count
     function updateResultsCount() {
         const visibleCards = $('.crcm-vehicle-card:visible').length;

--- a/costabilerent-theme/page-search-results.php
+++ b/costabilerent-theme/page-search-results.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Search Results Page Template
+ *
+ * Displays vehicle search results using the [crcm_vehicle_list] shortcode.
+ *
+ * @package Costabilerent Theme
+ */
+
+get_header();
+
+// Allowed query parameters to pass to the shortcode.
+$allowed_params = array(
+    'pickup_date',
+    'return_date',
+    'pickup_time',
+    'return_time',
+    'pickup_location',
+    'return_location',
+    'type',
+    'per_page',
+    'page',
+);
+
+$attrs = array();
+foreach ( $allowed_params as $param ) {
+    if ( isset( $_GET[ $param ] ) ) {
+        $value      = sanitize_text_field( wp_unslash( $_GET[ $param ] ) );
+        $attrs[] = sprintf( '%s="%s"', $param, esc_attr( $value ) );
+    }
+}
+
+$shortcode = '[crcm_vehicle_list ' . implode( ' ', $attrs ) . ']';
+
+echo do_shortcode( $shortcode );
+
+get_footer();

--- a/templates/frontend/vehicle-list.php
+++ b/templates/frontend/vehicle-list.php
@@ -25,8 +25,9 @@ $return_time = ! empty( sanitize_text_field( $_GET['return_time'] ?? '' ) )
     ? sanitize_text_field( $_GET['return_time'] )
     : '18:00';
 
-// Get vehicle types for filtering
+// Get vehicle types and locations for filtering
 $vehicle_types = crcm_get_vehicle_types();
+$locations     = crcm_get_locations();
 
 // Pagination parameters
 $per_page = isset( $_GET['per_page'] ) ? absint( $_GET['per_page'] ) : 10;
@@ -114,7 +115,19 @@ if ($pickup_date && $return_date) {
                     <?php endforeach; ?>
                 </select>
             </div>
-            
+
+            <div class="crcm-filter-group">
+                <label for="location-filter"><?php _e('Sede:', 'custom-rental-manager'); ?></label>
+                <select id="location-filter" class="crcm-filter-select">
+                    <option value=""><?php _e('Tutte le sedi', 'custom-rental-manager'); ?></option>
+                    <?php foreach ($locations as $location): ?>
+                        <option value="<?php echo esc_attr($location->slug); ?>">
+                            <?php echo esc_html($location->name); ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+
             <div class="crcm-filter-group">
                 <label for="price-sort-filter"><?php _e('Ordina per prezzo:', 'custom-rental-manager'); ?></label>
                 <select id="price-sort-filter" class="crcm-filter-select">
@@ -149,6 +162,10 @@ if ($pickup_date && $return_date) {
                 }
                 $thumbnail = get_the_post_thumbnail($vehicle->ID, 'medium');
                 $features  = get_post_meta($vehicle->ID, '_crcm_vehicle_features', true) ?: array();
+                $vehicle_location = get_post_meta($vehicle->ID, '_crcm_vehicle_location', true);
+                if (! $vehicle_location) {
+                    $vehicle_location = 'ischia-porto';
+                }
                 
                 // Check availability for selected dates
                 $available_quantity = 0;
@@ -172,8 +189,9 @@ if ($pickup_date && $return_date) {
                 }
                 
             ?>
-                <div class="crcm-vehicle-card <?php echo $is_available ? 'available' : 'unavailable'; ?>" 
+                <div class="crcm-vehicle-card <?php echo $is_available ? 'available' : 'unavailable'; ?>"
                      data-vehicle-type="<?php echo esc_attr($vehicle_type_slug); ?>"
+                     data-location="<?php echo esc_attr($vehicle_location); ?>"
                      data-daily-rate="<?php echo esc_attr($daily_rate); ?>"
                      data-vehicle-id="<?php echo esc_attr($vehicle->ID); ?>">
                      


### PR DESCRIPTION
## Summary
- add `page-search-results.php` template that forwards query string options to `[crcm_vehicle_list]`
- extend vehicle list template with location filter and card metadata
- enhance frontend JS with location filter handling and AJAX pagination

## Testing
- `php -l costabilerent-theme/page-search-results.php templates/frontend/vehicle-list.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b6e323a1c8333b7eef706e6c4662c