### PR TITLE
Add booking page template and dynamic booking summary

### DIFF
--- a/assets/css/frontend-booking-form.css
+++ b/assets/css/frontend-booking-form.css
@@ -8,6 +8,20 @@
     margin-bottom: 30px;
 }
 
+.crcm-step-dates {
+    margin-top: 15px;
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+
+.crcm-step-dates label {
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
 .crcm-breadcrumb {
     margin-bottom: 15px;
 }

--- a/costabilerent-theme/page-booking.php
+++ b/costabilerent-theme/page-booking.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Booking Page Template
+ *
+ * Displays the booking form using the [crcm_booking_form] shortcode.
+ *
+ * @package Costabilerent Theme
+ */
+
+get_header();
+
+// Allowed query parameters to pass to the shortcode.
+$allowed_params = array(
+    'vehicle',
+    'pickup_date',
+    'return_date',
+    'pickup_time',
+    'return_time',
+    'pickup_location',
+    'return_location',
+);
+
+$attrs = array();
+foreach ( $allowed_params as $param ) {
+    if ( isset( $_GET[ $param ] ) ) {
+        $value    = sanitize_text_field( wp_unslash( $_GET[ $param ] ) );
+        $attrs[] = sprintf( '%s="%s"', $param, esc_attr( $value ) );
+    }
+}
+
+echo do_shortcode( '[crcm_booking_form ' . implode( ' ', $attrs ) . ']' );
+
+get_footer();

--- a/custom-rental-car-manager.php
+++ b/custom-rental-car-manager.php
@@ -567,6 +567,11 @@ class CRCM_Plugin {
             }
         }
 
+        $end_date = new DateTime($pickup_date ?: date('Y-m-d'));
+        $end_date->add(new DateInterval('P' . $rental_days . 'D'));
+        $base_total_calc  = crcm_calculate_vehicle_pricing($vehicle_id, $pickup_date, $end_date->format('Y-m-d'));
+        $extra_daily_rate = $rental_days > 0 ? max(0, ($base_total_calc - ($daily_rate * $rental_days)) / $rental_days) : 0;
+
         $currency_symbol = crcm_get_setting('currency_symbol', '€');
 
         wp_enqueue_style(
@@ -589,8 +594,11 @@ class CRCM_Plugin {
             'crcmBookingData',
             array(
                 'daily_rate'      => $daily_rate,
+                'extra_daily_rate'=> $extra_daily_rate,
                 'rental_days'     => $rental_days,
                 'currency_symbol' => $currency_symbol,
+                'days_label'      => __('giorni', 'custom-rental-manager'),
+                'free_label'      => __('Gratis', 'custom-rental-manager'),
             )
         );
 

--- a/templates/frontend/booking-form.php
+++ b/templates/frontend/booking-form.php
@@ -76,6 +76,18 @@ $base_total = $base_total_calc;
             <a href="javascript:history.back()" class="crcm-back-link">← <?php _e('Cambia veicolo o date', 'custom-rental-manager'); ?></a>
         </div>
         <h1><?php _e('Prenota il tuo veicolo', 'custom-rental-manager'); ?></h1>
+        <div class="crcm-step-dates">
+            <label for="header_pickup_date">
+                <?php _e('Ritiro', 'custom-rental-manager'); ?>
+                <input type="date" id="header_pickup_date" value="<?php echo esc_attr($pickup_date); ?>" />
+                <input type="time" id="header_pickup_time" value="<?php echo esc_attr($pickup_time); ?>" />
+            </label>
+            <label for="header_return_date">
+                <?php _e('Riconsegna', 'custom-rental-manager'); ?>
+                <input type="date" id="header_return_date" value="<?php echo esc_attr($return_date); ?>" />
+                <input type="time" id="header_return_time" value="<?php echo esc_attr($return_time); ?>" />
+            </label>
+        </div>
     </div>
     
     <div class="crcm-booking-wrapper">


### PR DESCRIPTION
## Summary
- add `page-booking.php` template that renders `[crcm_booking_form]`
- enable editing pickup/return dates from booking step header
- update sidebar pricing to list free extras and recalc totals

## Testing
- `phpcs costabilerent-theme/page-booking.php custom-rental-car-manager.php templates/frontend/booking-form.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b70f1b61c83339eae2bd52502998c