### PR TITLE
Implement Stripe checkout flow with confirmation page

### DIFF
--- a/costabilerent-theme/page-confirmation.php
+++ b/costabilerent-theme/page-confirmation.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Booking Confirmation Page
+ *
+ * @package Costabilerent Theme
+ */
+
+get_header();
+
+$booking_id = isset($_GET['booking_id']) ? intval($_GET['booking_id']) : 0;
+$booking    = $booking_id ? crcm()->booking_manager->get_booking($booking_id) : null;
+
+if (!$booking || is_wp_error($booking)) :
+    ?>
+    <p><?php esc_html_e('Booking not found.', 'custom-rental-manager'); ?></p>
+    <?php
+    get_footer();
+    return;
+endif;
+
+$currency_symbol = crcm_get_setting('currency_symbol', '€');
+$vehicle_title   = get_the_title($booking['booking_data']['vehicle_id']);
+?>
+
+<div class="crcm-confirmation">
+    <h1><?php esc_html_e('Booking Confirmed', 'custom-rental-manager'); ?></h1>
+    <p>
+        <?php
+        printf(
+            esc_html__('Your booking code is %s', 'custom-rental-manager'),
+            '<strong>' . esc_html($booking['booking_number']) . '</strong>'
+        );
+        ?>
+    </p>
+
+    <h2><?php esc_html_e('Summary', 'custom-rental-manager'); ?></h2>
+    <ul>
+        <li><strong><?php esc_html_e('Vehicle', 'custom-rental-manager'); ?>:</strong> <?php echo esc_html($vehicle_title); ?></li>
+        <li><strong><?php esc_html_e('Pickup', 'custom-rental-manager'); ?>:</strong> <?php echo esc_html(date_i18n('d/m/Y', strtotime($booking['booking_data']['pickup_date'])) . ' ' . $booking['booking_data']['pickup_time']); ?></li>
+        <li><strong><?php esc_html_e('Return', 'custom-rental-manager'); ?>:</strong> <?php echo esc_html(date_i18n('d/m/Y', strtotime($booking['booking_data']['return_date'])) . ' ' . $booking['booking_data']['return_time']); ?></li>
+        <li><strong><?php esc_html_e('Total', 'custom-rental-manager'); ?>:</strong> <?php echo esc_html(crcm_format_price($booking['pricing_breakdown']['final_total'] ?? 0, $currency_symbol)); ?></li>
+    </ul>
+</div>
+
+<?php get_footer(); ?>
+

--- a/inc/class-payment-manager.php
+++ b/inc/class-payment-manager.php
@@ -278,7 +278,7 @@ class CRCM_Payment_Manager {
                         'booking_id'        => $booking_id,
                         'session_id'        => '{CHECKOUT_SESSION_ID}',
                     ),
-                    home_url('/customer-dashboard/')
+                    home_url('/confirmation/')
                 ),
                 'cancel_url' => home_url('/customer-dashboard/'),
             ));
@@ -339,7 +339,7 @@ class CRCM_Payment_Manager {
                 }
             }
 
-            wp_safe_redirect(home_url('/customer-dashboard/'));
+            wp_safe_redirect(add_query_arg('booking_id', $booking_id, home_url('/confirmation/')));
             exit;
         }
     }


### PR DESCRIPTION
## Summary
- add REST endpoint to create Stripe checkout session
- redirect Stripe success to confirmation page showing booking code
- integrate booking form with API and Stripe checkout

## Testing
- `php -l inc/class-payment-manager.php`
- `php -l inc/class-api-endpoints.php`
- `php -l costabilerent-theme/page-confirmation.php`
- `node --check assets/js/frontend-booking-form.js`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b72ae22fc8333b0f77dcc30d797f0