### PR TITLE
Add customer dashboard template with role-based access control

### DIFF
--- a/costabilerent-theme/page-dashboard.php
+++ b/costabilerent-theme/page-dashboard.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Template Name: Customer Dashboard
+ *
+ * Displays the rental customer dashboard.
+ *
+ * @package CostabilerentTheme
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! is_user_logged_in() ) {
+	wp_safe_redirect( wp_login_url( get_permalink() ) );
+	exit;
+}
+
+$user = wp_get_current_user();
+if ( ! in_array( 'crcm_customer', (array) $user->roles, true ) ) {
+	wp_safe_redirect( home_url() );
+	exit;
+}
+
+get_header();
+
+echo do_shortcode( '[crcm_customer_dashboard]' );
+
+get_footer();

--- a/custom-rental-car-manager.php
+++ b/custom-rental-car-manager.php
@@ -616,7 +616,11 @@ class CRCM_Plugin {
         if (!is_user_logged_in()) {
             return '<p>' . esc_html__('Please log in to access your dashboard.', 'custom-rental-manager') . '</p>';
         }
-        
+
+        if (!crcm_user_is_customer()) {
+            return '<p>' . esc_html__('Access restricted to rental customers.', 'custom-rental-manager') . '</p>';
+        }
+
         wp_enqueue_style(
             'crcm-customer-dashboard',
             CRCM_PLUGIN_URL . 'assets/css/frontend-customer-dashboard.css',


### PR DESCRIPTION
## Summary
- Add `page-dashboard.php` template rendering the `[crcm_customer_dashboard]` shortcode
- Restrict dashboard shortcode and template access to users with the `crcm_customer` role

## Testing
- `phpunit`
- `~/.local/share/mise/installs/php/8.3.24/.composer/vendor/bin/phpcs -p --standard=WordPress costabilerent-theme/page-dashboard.php`
- `~/.local/share/mise/installs/php/8.3.24/.composer/vendor/bin/phpcs -p --standard=WordPress custom-rental-car-manager.php` *(fails: numerous pre-existing coding standard violations)*


------
https://chatgpt.com/codex/tasks/task_e_689b74e7c9e0833395fdf18ae47679c5