### PR TITLE
Cache top vehicles query on front page

### DIFF
--- a/costabilerent-theme/front-page.php
+++ b/costabilerent-theme/front-page.php
@@ -15,72 +15,78 @@ get_header();
 
 <?php
 // Get top rented vehicles from last 30 days.
-$bookings = get_posts(
-    array(
-        'post_type'      => 'crcm_booking',
-        'post_status'    => 'publish',
-        'posts_per_page' => -1,
-        'date_query'     => array(
-            array(
-                'after' => date('Y-m-d', strtotime('-30 days')),
+$top_vehicle_ids = get_transient( 'crcm_top_rented_vehicle_ids' );
+
+if ( false === $top_vehicle_ids ) {
+    $bookings = get_posts(
+        array(
+            'post_type'      => 'crcm_booking',
+            'post_status'    => 'publish',
+            'posts_per_page' => 20,
+            'date_query'     => array(
+                array(
+                    'after' => date( 'Y-m-d', strtotime( '-30 days' ) ),
+                ),
             ),
-        ),
-        'fields'         => 'ids',
-    )
-);
+            'fields'         => 'ids',
+        )
+    );
 
-$vehicle_counts = array();
+    $vehicle_counts = array();
 
-foreach ($bookings as $booking_id) {
-    $booking_data = get_post_meta($booking_id, '_crcm_booking_data', true);
+    foreach ( $bookings as $booking_id ) {
+        $booking_data = get_post_meta( $booking_id, '_crcm_booking_data', true );
 
-    if (isset($booking_data['vehicle_id'])) {
-        $vehicle_id = absint($booking_data['vehicle_id']);
-        if (! isset($vehicle_counts[ $vehicle_id ])) {
-            $vehicle_counts[ $vehicle_id ] = 0;
+        if ( isset( $booking_data['vehicle_id'] ) ) {
+            $vehicle_id = absint( $booking_data['vehicle_id'] );
+            if ( ! isset( $vehicle_counts[ $vehicle_id ] ) ) {
+                $vehicle_counts[ $vehicle_id ] = 0;
+            }
+            $vehicle_counts[ $vehicle_id ]++;
         }
-        $vehicle_counts[ $vehicle_id ]++;
     }
+
+    arsort( $vehicle_counts );
+    $top_vehicle_ids = array_slice( array_keys( $vehicle_counts ), 0, 4 );
+
+    set_transient( 'crcm_top_rented_vehicle_ids', $top_vehicle_ids, HOUR_IN_SECONDS );
 }
 
-arsort($vehicle_counts);
-$top_vehicle_ids = array_slice(array_keys($vehicle_counts), 0, 4);
-
-if ($top_vehicle_ids) :
+if ( $top_vehicle_ids ) :
     ?>
     <div class="crcm-top-vehicles">
         <?php
-        foreach ($top_vehicle_ids as $vehicle_id) :
-            $vehicle = get_post($vehicle_id);
-            if (! $vehicle || 'crcm_vehicle' !== $vehicle->post_type) {
+        foreach ( $top_vehicle_ids as $vehicle_id ) :
+            $vehicle = get_post( $vehicle_id );
+            if ( ! $vehicle || 'crcm_vehicle' !== $vehicle->post_type ) {
                 continue;
             }
 
-            $title        = get_the_title($vehicle_id);
+            $title        = get_the_title( $vehicle_id );
             $image        = get_the_post_thumbnail(
                 $vehicle_id,
                 'medium',
-                array('class' => 'crcm-top-vehicles__image')
+                array( 'class' => 'crcm-top-vehicles__image' )
             );
-            $seats        = get_post_meta($vehicle_id, '_crcm_seats', true);
-            $transmission = get_post_meta($vehicle_id, '_crcm_transmission', true);
-            $rate         = get_post_meta($vehicle_id, '_crcm_daily_rate', true);
+            $seats        = get_post_meta( $vehicle_id, '_crcm_seats', true );
+            $transmission = get_post_meta( $vehicle_id, '_crcm_transmission', true );
+            $rate         = get_post_meta( $vehicle_id, '_crcm_daily_rate', true );
             ?>
             <div class="crcm-top-vehicles__card">
-                <?php if ($image) : ?>
+                <?php if ( $image ) : ?>
                     <div class="crcm-top-vehicles__thumb">
                         <?php echo $image; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
                     </div>
                 <?php endif; ?>
                 <div class="crcm-top-vehicles__content">
-                    <h3 class="crcm-top-vehicles__title"><?php echo esc_html($title); ?></h3>
+                    <h3 class="crcm-top-vehicles__title"><?php echo esc_html( $title ); ?></h3>
                     <p class="crcm-top-vehicles__meta">
-                        <?php echo esc_html($transmission); ?> |
-                        <?php echo esc_html($seats); ?>
-                        <?php echo esc_html__('Seats', 'custom-rental-manager'); ?>
+                        <?php echo esc_html( $transmission ); ?> |
+                        <?php echo esc_html( $seats ); ?>
+                        <?php echo esc_html__( 'Seats', 'custom-rental-manager' ); ?>
                     </p>
                     <p class="crcm-top-vehicles__rate">
-                        <?php echo esc_html(sprintf('€%s/%s', $rate, __('day', 'custom-rental-manager'))); ?>
+                        <?php echo esc_html( sprintf( '€%s/%s', $rate, __( 'day', 'custom-rental-manager' ) ) ); ?>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- limit booking query to 20 posts and fetch only IDs for counting
- cache top vehicle results in transient to avoid repeated queries

## Testing
- `php -l costabilerent-theme/front-page.php`
- `./phpunit.phar`


------
https://chatgpt.com/codex/tasks/task_e_689b85f8aee48333ba9383d2b66e2e2f