### PR TITLE
Use costabilerent text domain in theme translations

### DIFF
--- a/costabilerent-theme/front-page.php
+++ b/costabilerent-theme/front-page.php
@@ -83,10 +83,10 @@ if ( $top_vehicle_ids ) :
                     <p class="crcm-top-vehicles__meta">
                         <?php echo esc_html( $transmission ); ?> |
                         <?php echo esc_html( $seats ); ?>
-                        <?php echo esc_html__( 'Seats', 'custom-rental-manager' ); ?>
+                        <?php echo esc_html__( 'Seats', 'costabilerent' ); ?>
                     </p>
                     <p class="crcm-top-vehicles__rate">
-                        <?php echo esc_html( sprintf( '€%s/%s', $rate, __( 'day', 'custom-rental-manager' ) ) ); ?>
+                        <?php echo esc_html( sprintf( '€%s/%s', $rate, __( 'day', 'costabilerent' ) ) ); ?>
                     </p>
                 </div>
             </div>

--- a/costabilerent-theme/page-confirmation.php
+++ b/costabilerent-theme/page-confirmation.php
@@ -12,7 +12,7 @@ $booking    = $booking_id ? crcm()->booking_manager->get_booking($booking_id) : 
 
 if (!$booking || is_wp_error($booking)) :
     ?>
-    <p><?php esc_html_e('Booking not found.', 'custom-rental-manager'); ?></p>
+    <p><?php esc_html_e('Booking not found.', 'costabilerent'); ?></p>
     <?php
     get_footer();
     return;
@@ -23,22 +23,22 @@ $vehicle_title   = get_the_title($booking['booking_data']['vehicle_id']);
 ?>
 
 <div class="crcm-confirmation">
-    <h1><?php esc_html_e('Booking Confirmed', 'custom-rental-manager'); ?></h1>
+    <h1><?php esc_html_e('Booking Confirmed', 'costabilerent'); ?></h1>
     <p>
         <?php
         printf(
-            esc_html__('Your booking code is %s', 'custom-rental-manager'),
+            esc_html__('Your booking code is %s', 'costabilerent'),
             '<strong>' . esc_html($booking['booking_number']) . '</strong>'
         );
         ?>
     </p>
 
-    <h2><?php esc_html_e('Summary', 'custom-rental-manager'); ?></h2>
+    <h2><?php esc_html_e('Summary', 'costabilerent'); ?></h2>
     <ul>
-        <li><strong><?php esc_html_e('Vehicle', 'custom-rental-manager'); ?>:</strong> <?php echo esc_html($vehicle_title); ?></li>
-        <li><strong><?php esc_html_e('Pickup', 'custom-rental-manager'); ?>:</strong> <?php echo esc_html(date_i18n('d/m/Y', strtotime($booking['booking_data']['pickup_date'])) . ' ' . $booking['booking_data']['pickup_time']); ?></li>
-        <li><strong><?php esc_html_e('Return', 'custom-rental-manager'); ?>:</strong> <?php echo esc_html(date_i18n('d/m/Y', strtotime($booking['booking_data']['return_date'])) . ' ' . $booking['booking_data']['return_time']); ?></li>
-        <li><strong><?php esc_html_e('Total', 'custom-rental-manager'); ?>:</strong> <?php echo esc_html(crcm_format_price($booking['pricing_breakdown']['final_total'] ?? 0, $currency_symbol)); ?></li>
+        <li><strong><?php esc_html_e('Vehicle', 'costabilerent'); ?>:</strong> <?php echo esc_html($vehicle_title); ?></li>
+        <li><strong><?php esc_html_e('Pickup', 'costabilerent'); ?>:</strong> <?php echo esc_html(date_i18n('d/m/Y', strtotime($booking['booking_data']['pickup_date'])) . ' ' . $booking['booking_data']['pickup_time']); ?></li>
+        <li><strong><?php esc_html_e('Return', 'costabilerent'); ?>:</strong> <?php echo esc_html(date_i18n('d/m/Y', strtotime($booking['booking_data']['return_date'])) . ' ' . $booking['booking_data']['return_time']); ?></li>
+        <li><strong><?php esc_html_e('Total', 'costabilerent'); ?>:</strong> <?php echo esc_html(crcm_format_price($booking['pricing_breakdown']['final_total'] ?? 0, $currency_symbol)); ?></li>
     </ul>
 </div>
 


### PR DESCRIPTION
## Summary
- switch booking confirmation template to use `costabilerent` text domain
- update front page top vehicles strings to `costabilerent` text domain

## Testing
- `php -l costabilerent-theme/page-confirmation.php`
- `php -l costabilerent-theme/front-page.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b8aee2cac83339968c4493fc4a633