### PR TITLE
docs: add theme guidelines and update structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ text
 ├─ /templates/          # Custom admin/checkout templates
 ├─ /assets/             # CSS (backend & frontend), JS (admin, booking wizard)
 ├─ /languages/          # .pot for translation
+├─ /costabilerent-theme/ # Frontend theme (templates, assets, styles)
 ├─ /api/                # REST endpoint handlers
 └─ README.md/AGENTS.md
 🛠️ Development Guidelines for AI/AGENT
@@ -106,6 +107,11 @@ Run linter and automated test suite before merging
 No direct changes to main branch without approval unless urgent fix
 
 QA/focus on accessibility (WCAG 2.1)
+
+🎨 Theme Development
+- **Styles:** Place custom CSS/JS in `costabilerent-theme/assets/` and `style.css`; follow BEM naming and enqueue only where needed.
+- **Translations:** Base strings in English, wrapped with `__()`/`_e()` using the `costabilerent` text domain. Store `.pot/.po/.mo` files in `costabilerent-theme/languages/`.
+- **Assets:** Version and minify assets; load them via `wp_enqueue_style()` and `wp_enqueue_script()` to ensure caching and performance.
 
 🚀 Example Output / Expected UX
 “Fiat 500, Automatic, 4 Seats — €45/day”

--- a/costabilerent-theme/README.md
+++ b/costabilerent-theme/README.md
@@ -1,1 +1,22 @@
+# Costabilerent Theme
+
+Development guidelines for the Costabilerent front‑end theme.
+
+## Styles
+
+- Main stylesheet located in `style.css`; additional styles in `assets/css/main.css`.
+- Follow BEM-style naming and Totaliweb/Costabilerent branding.
+- Minify and version compiled CSS for production.
+
+## Translations
+
+- Base language is English.
+- Use the `costabilerent` text domain in all translation functions.
+- Place `.pot`, `.po`, and `.mo` files inside `languages/` and load them via `load_theme_textdomain()`.
+
+## Assets
+
+- Enqueue CSS and JS through `functions.php` using `wp_enqueue_style()` and `wp_enqueue_script()`.
+- Store unminified sources under `assets/` (`css/`, `js/`) and load only where required.
+- Version assets to leverage browser caching.
 


### PR DESCRIPTION
## Summary
- document `costabilerent-theme/` in folder structure
- add theme development guidelines for styles, translations, and assets

## Testing
- `find . -name '*.php' -not -path './vendor/*' -print0 | xargs -0 -n1 php -l`
- `~/.local/share/mise/installs/php/8.3.24/.composer/vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689b9e1e92d883338e530d68720dafac