### PR TITLE
Add Stripe API settings and externalize booking lock JS

### DIFF
--- a/assets/js/admin-booking-lock.js
+++ b/assets/js/admin-booking-lock.js
@@ -1,0 +1,61 @@
+/**
+ * Booking edit lock interactions
+ */
+(function($){
+    $(function(){
+        var allowed = ['#pickup_time', '#pickup_location', '#return_location', '#home_delivery', '#delivery_address', '#internal_notes', '#booking_notes'];
+        $('#crcm_booking_details :input, #crcm_booking_customer :input, #crcm_booking_vehicle :input, #crcm_booking_pricing :input, #crcm_booking_status :input, #crcm_booking_notes :input').each(function(){
+            var id = '#' + $(this).attr('id');
+            if (allowed.indexOf(id) === -1) {
+                $(this).prop('disabled', true);
+            }
+        });
+
+        var data = window.crcm_booking_lock || {};
+
+        $('#crcm-cancel-booking').on('click', function(){
+            if(!confirm(data.confirm_cancel)) {
+                return;
+            }
+            $.post(data.ajax_url, {
+                action: 'crcm_admin_cancel_booking',
+                booking_id: data.booking_id,
+                nonce: data.nonce
+            }, function(response){
+                if(response.success){
+                    alert(response.data.message);
+                    location.reload();
+                } else {
+                    alert(response.data);
+                }
+            });
+        });
+
+        $('#crcm-refund-booking').on('click', function(){
+            var total = $('#final_total_input').val() || 0;
+            $('#crcm-refund-amount').val(total);
+            $('#crcm-refund-modal').show();
+        });
+
+        $('#crcm-cancel-refund').on('click', function(){
+            $('#crcm-refund-modal').hide();
+        });
+
+        $('#crcm-confirm-refund').on('click', function(){
+            var amount = parseFloat($('#crcm-refund-amount').val()) || 0;
+            $.post(data.ajax_url, {
+                action: 'crcm_process_refund',
+                booking_id: data.booking_id,
+                refund_amount: amount,
+                nonce: data.nonce
+            }, function(response){
+                if(response.success){
+                    alert(response.data.message);
+                    location.reload();
+                } else {
+                    alert(response.data);
+                }
+            });
+        });
+    });
+})(jQuery);

--- a/templates/admin/booking-edit.php
+++ b/templates/admin/booking-edit.php
@@ -8,9 +8,6 @@
 if (!defined('ABSPATH')) {
     exit;
 }
-global $post;
-$booking_id = $post->ID;
-$nonce      = wp_create_nonce('crcm_admin_nonce');
 ?>
 <div class="notice notice-warning">
     <p><?php esc_html_e('This booking is locked. Only pickup time, pickup location, return location, internal notes and customer notes can be edited.', 'custom-rental-manager'); ?></p>
@@ -31,66 +28,3 @@ $nonce      = wp_create_nonce('crcm_admin_nonce');
         </div>
     </div>
 </div>
-
-<script>
-    jQuery(function($){
-        const allowed = ['#pickup_time', '#pickup_location', '#return_location', '#home_delivery', '#delivery_address', '#internal_notes', '#booking_notes'];
-        $('#crcm_booking_details :input, #crcm_booking_customer :input, #crcm_booking_vehicle :input, #crcm_booking_pricing :input, #crcm_booking_status :input, #crcm_booking_notes :input').each(function(){
-            const id = '#' + $(this).attr('id');
-            if (allowed.indexOf(id) === -1) {
-                $(this).prop('disabled', true);
-            }
-        });
-
-        const bookingData = {
-            ajax_url: ajaxurl,
-            booking_id: <?php echo (int) $booking_id; ?>,
-            nonce: '<?php echo esc_js($nonce); ?>'
-        };
-
-        $('#crcm-cancel-booking').on('click', function(){
-            if(!confirm('<?php echo esc_js(__('Sei sicuro di voler cancellare questa prenotazione?', 'custom-rental-manager')); ?>')) {
-                return;
-            }
-            $.post(bookingData.ajax_url, {
-                action: 'crcm_admin_cancel_booking',
-                booking_id: bookingData.booking_id,
-                nonce: bookingData.nonce
-            }, function(response){
-                if(response.success){
-                    alert(response.data.message);
-                    location.reload();
-                } else {
-                    alert(response.data);
-                }
-            });
-        });
-
-        $('#crcm-refund-booking').on('click', function(){
-            const total = $('#final_total_input').val() || 0;
-            $('#crcm-refund-amount').val(total);
-            $('#crcm-refund-modal').show();
-        });
-
-        $('#crcm-cancel-refund').on('click', function(){
-            $('#crcm-refund-modal').hide();
-        });
-
-        $('#crcm-confirm-refund').on('click', function(){
-            const amount = parseFloat($('#crcm-refund-amount').val()) || 0;
-            $.post(bookingData.ajax_url, {
-                action: 'crcm_process_refund',
-                booking_id: bookingData.booking_id,
-                refund_amount: amount,
-                nonce: bookingData.nonce
-            }, function(response){
-                if(response.success){
-                    alert(response.data.message);
-                    location.reload();
-                } else {
-                    alert(response.data);
-                }
-            });
-        });
-    });
-</script>


### PR DESCRIPTION
## Summary
- register Stripe API key fields using WordPress Settings API
- move booking lock logic into dedicated asset and enqueue only for locked bookings

## Testing
- `php -l custom-rental-car-manager.php`
- `php -l templates/admin/booking-edit.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689bb5b6743083338dab2718d671b273