### PR TITLE
Refactor public endpoints and clarify plugin-theme separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 Il plugin **Custom Rental Car Manager** è un sistema completo e professionale per la gestione autonoleggio di auto e scooter, ideato per l'agenzia Costabilerent a Ischia. Include gestione veicoli, tariffe (base e personalizzate), disponibilità, servizi extra, assicurazioni, automazioni email, calendario dinamico e REST API. Le funzionalità front-end sono demandate al tema dedicato.
 
+A partire dalla versione corrente il plugin non include markup o componenti di interfaccia: form di ricerca, liste e checkout sono gestiti interamente dal tema tramite le API REST esposte.
+
 ## Caratteristiche principali
 
 - Gestione veicoli: modelli, stock, tariffe, immagini, servizi
@@ -18,6 +20,7 @@ Il plugin **Custom Rental Car Manager** è un sistema completo e professionale p
 - Disponibilità individuale, ricorrente e settimanale
 - Integrazione pagamenti Stripe via API
 - REST API per integrazione front-end su tema dedicato
+- Nessun output front-end: il tema consuma le API REST esposte
 - Calendario amministrativo in tempo reale
 - Automazioni email dinamiche
 - Compatibilità con PHP 8.0+, WP ultime versioni
@@ -35,13 +38,14 @@ Il plugin **Custom Rental Car Manager** è un sistema completo e professionale p
 
 ## Uso
 
-- Utilizza gli shortcode del tema `[crcm_search_form]`, `[crcm_vehicle_list]`, `[crcm_booking_form]`, `[crcm_customer_dashboard]`
-- Personalizza layout e stile in front-end tramite template override
+- Attiva il tema Costabilerent per ottenere form, liste e checkout
+- Il tema fornisce gli shortcode `[crcm_search_form]`, `[crcm_vehicle_list]`, `[crcm_booking_form]`, `[crcm_customer_dashboard]` che consumano le API REST del plugin
+- Personalizza layout e stile in front-end tramite template override del tema
 - Gestisci prenotazioni, veicoli, calendario in backend
 
-## Endpoint & Hook disponibili
+## Endpoint REST disponibili
 
-Il plugin espone endpoint REST che forniscono i dati degli shortcode e relativi hook per ulteriori personalizzazioni:
+Il plugin espone endpoint REST pubblici che il tema utilizza per renderizzare form, liste e checkout. Gli hook permettono al tema o ad altre estensioni di modificarne i dati:
 
 | Endpoint | Descrizione | Hook dati |
 | --- | --- | --- |

--- a/custom-rental-car-manager.php
+++ b/custom-rental-car-manager.php
@@ -60,7 +60,7 @@ class CRCM_Plugin {
     public $payment_manager;
     public $api_endpoints;
     public $locale_manager;
-    public $shortcode_endpoints;
+    public $public_endpoints;
 
     /**
      * Get single instance.
@@ -153,7 +153,7 @@ class CRCM_Plugin {
             'class-email-manager.php',
             'class-payment-manager.php',
             'class-api-endpoints.php',
-            'class-shortcode-endpoints.php',
+            'class-public-endpoints.php',
             'class-locale-manager.php'
         );
         
@@ -197,8 +197,8 @@ class CRCM_Plugin {
             $this->api_endpoints = new CRCM_API_Endpoints();
         }
 
-        if ( class_exists( 'CRCM_Shortcode_Endpoints' ) ) {
-            $this->shortcode_endpoints = new CRCM_Shortcode_Endpoints();
+        if ( class_exists( 'CRCM_Public_Endpoints' ) ) {
+            $this->public_endpoints = new CRCM_Public_Endpoints();
         }
 
         if ( class_exists( 'CRCM_Locale_Manager' ) ) {
@@ -433,7 +433,7 @@ class CRCM_Plugin {
     }
     
     /**
-     * Initialize shortcodes.
+     * Enqueue admin assets.
      *
      * @since 1.0.0
      *

--- a/inc/class-public-endpoints.php
+++ b/inc/class-public-endpoints.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * Shortcode Data Endpoints.
+ * Public Data Endpoints.
  *
- * Converts legacy shortcodes into REST data providers
- * so the theme can render markup separately.
+ * Provides REST data for the theme to render forms, lists and checkouts.
  *
  * @package CustomRentalCarManager
  */
@@ -13,10 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Class handling REST endpoints that expose data formerly delivered
- * by plugin shortcodes.
+ * Class handling public REST endpoints used by the theme.
  */
-class CRCM_Shortcode_Endpoints {
+class CRCM_Public_Endpoints {
 
     /**
      * Constructor.


### PR DESCRIPTION
## Summary
- Rename shortcode endpoint handler to `CRCM_Public_Endpoints` and update plugin bootstrap
- Document headless architecture and REST interfaces used by the theme

## Testing
- `phpcs --standard=PSR12 inc/class-public-endpoints.php` *(fails: numerous style warnings)*
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689c3c94dcc8833383b405c0cfe8cf1a